### PR TITLE
feat: Markdownパーサー（ファイル走査・heading分割・frontmatter/tag抽出）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,10 +166,12 @@ dependencies = [
  "predicates",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tempfile",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "walkdir",
 ]
 
 [[package]]
@@ -509,6 +511,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,6 +572,19 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -734,6 +764,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -746,6 +782,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -798,6 +844,15 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ serde_json = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter", "ansi", "registry"] }
 tracing-appender = "0.2"
+serde_yaml = "0.9"
+walkdir = "2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //
 // Module declarations will be added as implementation progresses:
 // pub mod cli;
-// pub mod parser;
+pub mod parser;
 // pub mod indexer;
 // pub mod search;
 // pub mod output;

--- a/src/parser/frontmatter.rs
+++ b/src/parser/frontmatter.rs
@@ -1,0 +1,118 @@
+use serde::Deserialize;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct Frontmatter {
+    pub tags: Vec<String>,
+    pub raw: HashMap<String, serde_json::Value>,
+}
+
+#[derive(Deserialize)]
+struct RawFrontmatter {
+    #[serde(default)]
+    tags: Option<TagsValue>,
+    #[serde(flatten)]
+    rest: HashMap<String, serde_yaml::Value>,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum TagsValue {
+    List(Vec<String>),
+    Single(String),
+}
+
+/// frontmatter 文字列（YAML）をパースする
+pub fn parse_frontmatter(yaml_str: &str) -> Option<Frontmatter> {
+    let raw_fm: RawFrontmatter = serde_yaml::from_str(yaml_str).ok()?;
+
+    let tags = match raw_fm.tags {
+        Some(TagsValue::List(list)) => list,
+        Some(TagsValue::Single(s)) => s.split(',').map(|t| t.trim().to_string()).collect(),
+        None => Vec::new(),
+    };
+
+    let raw: HashMap<String, serde_json::Value> = raw_fm
+        .rest
+        .into_iter()
+        .filter_map(|(k, v)| {
+            let json_str = serde_json::to_string(&serde_yaml_to_json(v)).ok()?;
+            let json_val = serde_json::from_str(&json_str).ok()?;
+            Some((k, json_val))
+        })
+        .collect();
+
+    Some(Frontmatter { tags, raw })
+}
+
+/// Markdownテキストからfrontmatter部分を抽出する
+/// 戻り値: (frontmatter文字列, frontmatter以降のコンテンツ, frontmatter行数)
+pub fn extract_frontmatter(content: &str) -> (Option<String>, &str, usize) {
+    let trimmed = content.trim_start();
+    if !trimmed.starts_with("---") {
+        return (None, content, 0);
+    }
+
+    // Find the opening ---
+    let start = content.find("---").unwrap();
+    let after_first = start + 3;
+    let rest = &content[after_first..];
+
+    // Skip the newline after ---
+    let rest = rest
+        .strip_prefix('\n')
+        .or_else(|| rest.strip_prefix("\r\n"))
+        .unwrap_or(rest);
+
+    // Find closing ---
+    if let Some(end_pos) = rest.find("\n---") {
+        let yaml_str = &rest[..end_pos];
+        let after_close = end_pos + 4; // "\n---".len()
+        let remaining = &rest[after_close..];
+        let remaining = remaining
+            .strip_prefix('\n')
+            .or_else(|| remaining.strip_prefix("\r\n"))
+            .unwrap_or(remaining);
+
+        let fm_lines = content[..content.len() - remaining.len()].lines().count();
+        (Some(yaml_str.to_string()), remaining, fm_lines)
+    } else {
+        (None, content, 0)
+    }
+}
+
+fn serde_yaml_to_json(val: serde_yaml::Value) -> serde_json::Value {
+    match val {
+        serde_yaml::Value::Null => serde_json::Value::Null,
+        serde_yaml::Value::Bool(b) => serde_json::Value::Bool(b),
+        serde_yaml::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                serde_json::Value::Number(i.into())
+            } else if let Some(f) = n.as_f64() {
+                serde_json::Number::from_f64(f)
+                    .map(serde_json::Value::Number)
+                    .unwrap_or(serde_json::Value::Null)
+            } else {
+                serde_json::Value::Null
+            }
+        }
+        serde_yaml::Value::String(s) => serde_json::Value::String(s),
+        serde_yaml::Value::Sequence(seq) => {
+            serde_json::Value::Array(seq.into_iter().map(serde_yaml_to_json).collect())
+        }
+        serde_yaml::Value::Mapping(map) => {
+            let obj: serde_json::Map<String, serde_json::Value> = map
+                .into_iter()
+                .map(|(k, v)| {
+                    let key = match k {
+                        serde_yaml::Value::String(s) => s,
+                        other => format!("{other:?}"),
+                    };
+                    (key, serde_yaml_to_json(v))
+                })
+                .collect();
+            serde_json::Value::Object(obj)
+        }
+        serde_yaml::Value::Tagged(tagged) => serde_yaml_to_json(tagged.value),
+    }
+}

--- a/src/parser/link.rs
+++ b/src/parser/link.rs
@@ -1,0 +1,87 @@
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum LinkType {
+    WikiLink,
+    MarkdownLink,
+}
+
+impl fmt::Display for LinkType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LinkType::WikiLink => write!(f, "WikiLink"),
+            LinkType::MarkdownLink => write!(f, "MarkdownLink"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Link {
+    pub target: String,
+    pub link_type: LinkType,
+}
+
+/// テキストからリンクを抽出する
+pub fn extract_links(content: &str) -> Vec<Link> {
+    let mut links = Vec::new();
+
+    // WikiLink: [[target]]
+    extract_wiki_links(content, &mut links);
+
+    // MarkdownLink: [text](target)
+    extract_markdown_links(content, &mut links);
+
+    links
+}
+
+fn extract_wiki_links(content: &str, links: &mut Vec<Link>) {
+    let mut rest = content;
+    while let Some(start) = rest.find("[[") {
+        let after_open = start + 2;
+        let remaining = &rest[after_open..];
+        if let Some(end) = remaining.find("]]") {
+            let target = &remaining[..end];
+            if !target.is_empty() && !target.contains('\n') {
+                links.push(Link {
+                    target: target.to_string(),
+                    link_type: LinkType::WikiLink,
+                });
+            }
+            rest = &remaining[end + 2..];
+        } else {
+            break;
+        }
+    }
+}
+
+fn extract_markdown_links(content: &str, links: &mut Vec<Link>) {
+    let mut rest = content;
+    while let Some(bracket_start) = rest.find('[') {
+        let after_bracket = &rest[bracket_start + 1..];
+
+        // Skip wiki links
+        if rest[bracket_start..].starts_with("[[") {
+            rest = &rest[bracket_start + 2..];
+            continue;
+        }
+
+        if let Some(bracket_end) = after_bracket.find(']') {
+            let after_close = &after_bracket[bracket_end + 1..];
+            if after_close.starts_with('(')
+                && let Some(paren_end) = after_close.find(')')
+            {
+                let target = &after_close[1..paren_end];
+                if !target.is_empty() {
+                    links.push(Link {
+                        target: target.to_string(),
+                        link_type: LinkType::MarkdownLink,
+                    });
+                }
+                rest = &after_close[paren_end + 1..];
+                continue;
+            }
+        }
+
+        rest = &rest[bracket_start + 1..];
+    }
+}

--- a/src/parser/markdown.rs
+++ b/src/parser/markdown.rs
@@ -1,0 +1,144 @@
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use crate::parser::frontmatter::{self, Frontmatter};
+use crate::parser::link::{self, Link};
+
+#[derive(Debug)]
+pub enum ParseError {
+    Io(std::io::Error),
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ParseError::Io(e) => write!(f, "IO error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for ParseError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            ParseError::Io(e) => Some(e),
+        }
+    }
+}
+
+impl From<std::io::Error> for ParseError {
+    fn from(e: std::io::Error) -> Self {
+        ParseError::Io(e)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Section {
+    pub heading: String,
+    pub level: u8,
+    pub body: String,
+    pub line_start: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct MarkdownDocument {
+    pub path: PathBuf,
+    pub frontmatter: Option<Frontmatter>,
+    pub sections: Vec<Section>,
+    pub links: Vec<Link>,
+}
+
+/// Markdownファイルをパースする
+pub fn parse_file(path: &Path) -> Result<MarkdownDocument, ParseError> {
+    let content = std::fs::read_to_string(path)?;
+    let mut doc = parse_content(&content);
+    doc.path = path.to_path_buf();
+    Ok(doc)
+}
+
+/// Markdown文字列をパースする
+pub fn parse_content(content: &str) -> MarkdownDocument {
+    let (fm_str, body, fm_lines) = frontmatter::extract_frontmatter(content);
+
+    let frontmatter = fm_str.and_then(|s| frontmatter::parse_frontmatter(&s));
+    let sections = parse_sections(body, fm_lines);
+    let links = link::extract_links(body);
+
+    MarkdownDocument {
+        path: PathBuf::new(),
+        frontmatter,
+        sections,
+        links,
+    }
+}
+
+/// heading単位でセクションに分割する
+fn parse_sections(content: &str, line_offset: usize) -> Vec<Section> {
+    let mut sections = Vec::new();
+    let mut current_heading = String::new();
+    let mut current_level: u8 = 0;
+    let mut current_body = String::new();
+    let mut current_line_start = line_offset + 1;
+    let mut in_section = false;
+
+    for (i, line) in content.lines().enumerate() {
+        let line_num = line_offset + i + 1;
+
+        if let Some((level, heading)) = parse_heading_line(line) {
+            // Save previous section
+            if in_section {
+                sections.push(Section {
+                    heading: current_heading.clone(),
+                    level: current_level,
+                    body: current_body.trim_end().to_string(),
+                    line_start: current_line_start,
+                });
+            }
+
+            current_heading = heading;
+            current_level = level;
+            current_body = String::new();
+            current_line_start = line_num;
+            in_section = true;
+        } else if in_section && (!current_body.is_empty() || !line.is_empty()) {
+            if !current_body.is_empty() {
+                current_body.push('\n');
+            }
+            current_body.push_str(line);
+        }
+        // Lines before first heading are ignored (no section)
+    }
+
+    // Save last section
+    if in_section {
+        sections.push(Section {
+            heading: current_heading,
+            level: current_level,
+            body: current_body.trim_end().to_string(),
+            line_start: current_line_start,
+        });
+    }
+
+    sections
+}
+
+/// heading行をパースする。`# heading` → Some((1, "heading"))
+fn parse_heading_line(line: &str) -> Option<(u8, String)> {
+    let trimmed = line.trim_start();
+    if !trimmed.starts_with('#') {
+        return None;
+    }
+
+    let hashes = trimmed.chars().take_while(|&c| c == '#').count();
+    if hashes == 0 || hashes > 6 {
+        return None;
+    }
+
+    let rest = &trimmed[hashes..];
+    // Must have a space after # (or be just "#")
+    if !rest.is_empty() && !rest.starts_with(' ') {
+        return None;
+    }
+
+    let heading = rest.trim().to_string();
+    Some((hashes as u8, heading))
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,0 +1,28 @@
+pub mod frontmatter;
+pub mod link;
+pub mod markdown;
+
+pub use frontmatter::Frontmatter;
+pub use link::{Link, LinkType};
+pub use markdown::{MarkdownDocument, Section};
+
+use std::path::Path;
+use walkdir::WalkDir;
+
+use crate::parser::markdown::ParseError;
+
+/// 指定ディレクトリ配下の `.md` ファイルを再帰的に列挙し、パースする
+pub fn parse_directory(root: &Path) -> Result<Vec<MarkdownDocument>, ParseError> {
+    let mut documents = Vec::new();
+
+    for entry in WalkDir::new(root)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
+    {
+        let doc = markdown::parse_file(entry.path())?;
+        documents.push(doc);
+    }
+
+    Ok(documents)
+}

--- a/tests/parser_markdown.rs
+++ b/tests/parser_markdown.rs
@@ -1,0 +1,195 @@
+use commandindex::parser::{self, Link, LinkType};
+use std::fs;
+use tempfile::TempDir;
+
+// === Section parsing tests ===
+
+#[test]
+fn test_parse_heading_levels() {
+    let content = "# H1\n\nBody1\n\n## H2\n\nBody2\n\n### H3\n\nBody3";
+    let doc = parser::markdown::parse_content(content);
+
+    assert_eq!(doc.sections.len(), 3);
+    assert_eq!(doc.sections[0].heading, "H1");
+    assert_eq!(doc.sections[0].level, 1);
+    assert_eq!(doc.sections[0].body, "Body1");
+    assert_eq!(doc.sections[1].heading, "H2");
+    assert_eq!(doc.sections[1].level, 2);
+    assert_eq!(doc.sections[2].heading, "H3");
+    assert_eq!(doc.sections[2].level, 3);
+}
+
+#[test]
+fn test_parse_all_heading_levels() {
+    let content = "# H1\n## H2\n### H3\n#### H4\n##### H5\n###### H6";
+    let doc = parser::markdown::parse_content(content);
+
+    assert_eq!(doc.sections.len(), 6);
+    for (i, section) in doc.sections.iter().enumerate() {
+        assert_eq!(section.level, (i + 1) as u8);
+    }
+}
+
+#[test]
+fn test_empty_file() {
+    let doc = parser::markdown::parse_content("");
+    assert!(doc.sections.is_empty());
+    assert!(doc.frontmatter.is_none());
+    assert!(doc.links.is_empty());
+}
+
+#[test]
+fn test_no_headings() {
+    let content = "Just some text\nwithout any headings.";
+    let doc = parser::markdown::parse_content(content);
+    assert!(doc.sections.is_empty());
+}
+
+#[test]
+fn test_heading_without_space_is_not_heading() {
+    let content = "#not-a-heading\n# Real heading";
+    let doc = parser::markdown::parse_content(content);
+    assert_eq!(doc.sections.len(), 1);
+    assert_eq!(doc.sections[0].heading, "Real heading");
+}
+
+#[test]
+fn test_section_multiline_body() {
+    let content = "# Title\n\nLine 1\nLine 2\nLine 3";
+    let doc = parser::markdown::parse_content(content);
+
+    assert_eq!(doc.sections.len(), 1);
+    assert!(doc.sections[0].body.contains("Line 1"));
+    assert!(doc.sections[0].body.contains("Line 3"));
+}
+
+// === Frontmatter tests ===
+
+#[test]
+fn test_frontmatter_with_tags() {
+    let content = "---\ntags:\n  - rust\n  - cli\ntitle: Test\n---\n# Heading\n\nBody";
+    let doc = parser::markdown::parse_content(content);
+
+    assert!(doc.frontmatter.is_some());
+    let fm = doc.frontmatter.unwrap();
+    assert_eq!(fm.tags, vec!["rust", "cli"]);
+    assert!(fm.raw.contains_key("title"));
+}
+
+#[test]
+fn test_frontmatter_without_tags() {
+    let content = "---\ntitle: Test\nauthor: Someone\n---\n# Heading";
+    let doc = parser::markdown::parse_content(content);
+
+    assert!(doc.frontmatter.is_some());
+    let fm = doc.frontmatter.unwrap();
+    assert!(fm.tags.is_empty());
+}
+
+#[test]
+fn test_no_frontmatter() {
+    let content = "# Just a heading\n\nSome body text.";
+    let doc = parser::markdown::parse_content(content);
+    assert!(doc.frontmatter.is_none());
+    assert_eq!(doc.sections.len(), 1);
+}
+
+#[test]
+fn test_empty_frontmatter() {
+    let content = "---\n---\n# Heading";
+    let doc = parser::markdown::parse_content(content);
+    // Empty YAML may parse as None or empty frontmatter
+    assert_eq!(doc.sections.len(), 1);
+}
+
+// === Link extraction tests ===
+
+#[test]
+fn test_wiki_links() {
+    let content = "# Links\n\nSee [[target-page]] and [[another page]].";
+    let doc = parser::markdown::parse_content(content);
+
+    let wiki_links: Vec<&Link> = doc
+        .links
+        .iter()
+        .filter(|l| l.link_type == LinkType::WikiLink)
+        .collect();
+    assert_eq!(wiki_links.len(), 2);
+    assert_eq!(wiki_links[0].target, "target-page");
+    assert_eq!(wiki_links[1].target, "another page");
+}
+
+#[test]
+fn test_markdown_links() {
+    let content = "# Links\n\n[Click here](https://example.com) and [docs](./docs.md).";
+    let doc = parser::markdown::parse_content(content);
+
+    let md_links: Vec<&Link> = doc
+        .links
+        .iter()
+        .filter(|l| l.link_type == LinkType::MarkdownLink)
+        .collect();
+    assert_eq!(md_links.len(), 2);
+    assert_eq!(md_links[0].target, "https://example.com");
+    assert_eq!(md_links[1].target, "./docs.md");
+}
+
+#[test]
+fn test_mixed_links() {
+    let content = "# Mixed\n\n[[wiki]] and [md](target.md)";
+    let doc = parser::markdown::parse_content(content);
+    assert_eq!(doc.links.len(), 2);
+}
+
+// === Directory traversal tests ===
+
+#[test]
+fn test_parse_directory() {
+    let tmp = TempDir::new().unwrap();
+
+    // Create some .md files
+    fs::write(tmp.path().join("file1.md"), "# Title 1\n\nBody 1").unwrap();
+    fs::write(
+        tmp.path().join("file2.md"),
+        "---\ntags:\n  - test\n---\n# Title 2\n\nBody 2",
+    )
+    .unwrap();
+
+    // Create a subdirectory with another .md file
+    let sub = tmp.path().join("sub");
+    fs::create_dir(&sub).unwrap();
+    fs::write(sub.join("file3.md"), "# Nested\n\nNested body").unwrap();
+
+    // Create a non-.md file (should be ignored)
+    fs::write(tmp.path().join("readme.txt"), "Not markdown").unwrap();
+
+    let docs = parser::parse_directory(tmp.path()).unwrap();
+    assert_eq!(docs.len(), 3);
+}
+
+#[test]
+fn test_parse_empty_directory() {
+    let tmp = TempDir::new().unwrap();
+    let docs = parser::parse_directory(tmp.path()).unwrap();
+    assert!(docs.is_empty());
+}
+
+#[test]
+fn test_line_start_with_frontmatter() {
+    let content = "---\ntitle: Test\n---\n# Heading\n\nBody";
+    let doc = parser::markdown::parse_content(content);
+
+    assert_eq!(doc.sections.len(), 1);
+    // heading should be after frontmatter lines
+    assert!(doc.sections[0].line_start > 1);
+}
+
+#[test]
+fn test_line_start_without_frontmatter() {
+    let content = "# First\n\nBody\n\n## Second\n\nMore body";
+    let doc = parser::markdown::parse_content(content);
+
+    assert_eq!(doc.sections.len(), 2);
+    assert_eq!(doc.sections[0].line_start, 1);
+    assert!(doc.sections[1].line_start > 1);
+}


### PR DESCRIPTION
## Summary
- Markdownファイルのheading単位セクション分割機能を実装
- YAML frontmatter/tag抽出、WikiLink/MarkdownLink抽出を実装
- walkdirによるディレクトリ再帰走査を実装

## Test plan
- [x] heading単位分割テスト（#〜######）
- [x] frontmatter解析テスト（tags有/無、空）
- [x] リンク抽出テスト（WikiLink/MarkdownLink/混合）
- [x] ディレクトリ走査テスト（再帰、空、非mdファイル除外）
- [x] エッジケース（空ファイル、heading無しファイル）
- [x] cargo clippy / fmt / test 全パス

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)