### PR TITLE
feat: インデックス状態管理（manifest.json / state.json）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,6 +185,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bon"
 version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,6 +307,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -358,6 +390,7 @@ name = "commandindex"
 version = "0.0.0"
 dependencies = [
  "assert_cmd",
+ "chrono",
  "clap",
  "globset",
  "lindera",
@@ -366,6 +399,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "tantivy",
  "tempfile",
  "tracing",
@@ -389,6 +423,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crc32fast"
@@ -438,6 +481,16 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "csv"
@@ -581,6 +634,16 @@ name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "displaydoc"
@@ -840,6 +903,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1039,6 +1112,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "621debdf94dcac33e50475fdd76d34d5ea9c0362a834b9db08c3024696c1fbe3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -2358,6 +2455,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2913,6 +3021,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-blocks"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2998,6 +3112,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"
@@ -3205,10 +3325,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ globset = "0.4"
 tantivy = "0.25"
 lindera = { version = "2.3", features = ["embed-ipadic"] }
 lindera-tantivy = { version = "2.0", features = ["embed-ipadic"] }
+sha2 = "0.10"
+chrono = { version = "0.4", features = ["serde"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/indexer/manifest.rs
+++ b/src/indexer/manifest.rs
@@ -1,0 +1,108 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::fmt;
+use std::path::Path;
+
+const MANIFEST_FILE: &str = "manifest.json";
+
+#[derive(Debug)]
+pub enum ManifestError {
+    Io(std::io::Error),
+    Json(serde_json::Error),
+}
+
+impl fmt::Display for ManifestError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ManifestError::Io(e) => write!(f, "IO error: {e}"),
+            ManifestError::Json(e) => write!(f, "JSON error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for ManifestError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            ManifestError::Io(e) => Some(e),
+            ManifestError::Json(e) => Some(e),
+        }
+    }
+}
+
+impl From<std::io::Error> for ManifestError {
+    fn from(e: std::io::Error) -> Self {
+        ManifestError::Io(e)
+    }
+}
+
+impl From<serde_json::Error> for ManifestError {
+    fn from(e: serde_json::Error) -> Self {
+        ManifestError::Json(e)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FileEntry {
+    pub path: String,
+    pub hash: String,
+    pub last_modified: DateTime<Utc>,
+    pub sections: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Manifest {
+    pub files: Vec<FileEntry>,
+}
+
+impl Default for Manifest {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Manifest {
+    /// 空のマニフェストを作成する
+    pub fn new() -> Self {
+        Self { files: Vec::new() }
+    }
+
+    /// `.commandindex/` ディレクトリから manifest.json を読み込む
+    pub fn load(commandindex_dir: &Path) -> Result<Self, ManifestError> {
+        let path = commandindex_dir.join(MANIFEST_FILE);
+        let content = std::fs::read_to_string(&path)?;
+        let manifest: Self = serde_json::from_str(&content)?;
+        Ok(manifest)
+    }
+
+    /// `.commandindex/` ディレクトリに manifest.json を書き込む
+    pub fn save(&self, commandindex_dir: &Path) -> Result<(), ManifestError> {
+        std::fs::create_dir_all(commandindex_dir)?;
+        let path = commandindex_dir.join(MANIFEST_FILE);
+        let content = serde_json::to_string_pretty(self)?;
+        std::fs::write(&path, content)?;
+        Ok(())
+    }
+
+    /// ファイルエントリを追加する
+    pub fn add_entry(&mut self, entry: FileEntry) {
+        self.files.push(entry);
+    }
+
+    /// ファイル数を返す
+    pub fn file_count(&self) -> usize {
+        self.files.len()
+    }
+
+    /// パスでファイルエントリを検索する
+    pub fn find_by_path(&self, path: &str) -> Option<&FileEntry> {
+        self.files.iter().find(|e| e.path == path)
+    }
+}
+
+/// ファイルのSHA-256ハッシュを計算する
+pub fn compute_file_hash(path: &Path) -> Result<String, std::io::Error> {
+    let content = std::fs::read(path)?;
+    let hash = Sha256::digest(&content);
+    Ok(format!("sha256:{:x}", hash))
+}

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -1,3 +1,5 @@
+pub mod manifest;
 pub mod reader;
 pub mod schema;
+pub mod state;
 pub mod writer;

--- a/src/indexer/state.rs
+++ b/src/indexer/state.rs
@@ -1,0 +1,116 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+const STATE_FILE: &str = "state.json";
+const CURRENT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug)]
+pub enum StateError {
+    Io(std::io::Error),
+    Json(serde_json::Error),
+    SchemaVersionMismatch { expected: u32, found: u32 },
+}
+
+impl fmt::Display for StateError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            StateError::Io(e) => write!(f, "IO error: {e}"),
+            StateError::Json(e) => write!(f, "JSON error: {e}"),
+            StateError::SchemaVersionMismatch { expected, found } => {
+                write!(
+                    f,
+                    "Schema version mismatch: expected {expected}, found {found}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for StateError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            StateError::Io(e) => Some(e),
+            StateError::Json(e) => Some(e),
+            StateError::SchemaVersionMismatch { .. } => None,
+        }
+    }
+}
+
+impl From<std::io::Error> for StateError {
+    fn from(e: std::io::Error) -> Self {
+        StateError::Io(e)
+    }
+}
+
+impl From<serde_json::Error> for StateError {
+    fn from(e: serde_json::Error) -> Self {
+        StateError::Json(e)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct IndexState {
+    pub version: String,
+    pub schema_version: u32,
+    pub created_at: DateTime<Utc>,
+    pub last_updated_at: DateTime<Utc>,
+    pub total_files: u64,
+    pub total_sections: u64,
+    pub index_root: PathBuf,
+}
+
+impl IndexState {
+    /// 新しいインデックス状態を作成する
+    pub fn new(index_root: PathBuf) -> Self {
+        let now = Utc::now();
+        Self {
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            schema_version: CURRENT_SCHEMA_VERSION,
+            created_at: now,
+            last_updated_at: now,
+            total_files: 0,
+            total_sections: 0,
+            index_root,
+        }
+    }
+
+    /// `.commandindex/` ディレクトリから state.json を読み込む
+    pub fn load(commandindex_dir: &Path) -> Result<Self, StateError> {
+        let path = commandindex_dir.join(STATE_FILE);
+        let content = std::fs::read_to_string(&path)?;
+        let state: Self = serde_json::from_str(&content)?;
+        Ok(state)
+    }
+
+    /// `.commandindex/` ディレクトリに state.json を書き込む
+    pub fn save(&self, commandindex_dir: &Path) -> Result<(), StateError> {
+        std::fs::create_dir_all(commandindex_dir)?;
+        let path = commandindex_dir.join(STATE_FILE);
+        let content = serde_json::to_string_pretty(self)?;
+        std::fs::write(&path, content)?;
+        Ok(())
+    }
+
+    /// スキーマバージョンの整合性をチェックする
+    pub fn check_schema_version(&self) -> Result<(), StateError> {
+        if self.schema_version != CURRENT_SCHEMA_VERSION {
+            return Err(StateError::SchemaVersionMismatch {
+                expected: CURRENT_SCHEMA_VERSION,
+                found: self.schema_version,
+            });
+        }
+        Ok(())
+    }
+
+    /// インデックスが作成済みかどうかを判定する
+    pub fn exists(commandindex_dir: &Path) -> bool {
+        commandindex_dir.join(STATE_FILE).exists()
+    }
+
+    /// 更新時刻を現在時刻に更新する
+    pub fn touch(&mut self) {
+        self.last_updated_at = Utc::now();
+    }
+}

--- a/tests/indexer_state.rs
+++ b/tests/indexer_state.rs
@@ -1,0 +1,199 @@
+use chrono::Utc;
+use commandindex::indexer::manifest::{self, FileEntry, Manifest};
+use commandindex::indexer::state::IndexState;
+use std::fs;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+// === IndexState tests ===
+
+#[test]
+fn test_state_new() {
+    let state = IndexState::new(PathBuf::from("/test/repo"));
+    assert_eq!(state.schema_version, 1);
+    assert_eq!(state.total_files, 0);
+    assert_eq!(state.total_sections, 0);
+    assert_eq!(state.index_root, PathBuf::from("/test/repo"));
+}
+
+#[test]
+fn test_state_save_and_load() {
+    let tmp = TempDir::new().unwrap();
+    let ci_dir = tmp.path().join(".commandindex");
+
+    let state = IndexState::new(PathBuf::from("/test/repo"));
+    state.save(&ci_dir).unwrap();
+
+    let loaded = IndexState::load(&ci_dir).unwrap();
+    assert_eq!(state.version, loaded.version);
+    assert_eq!(state.schema_version, loaded.schema_version);
+    assert_eq!(state.total_files, loaded.total_files);
+    assert_eq!(state.index_root, loaded.index_root);
+}
+
+#[test]
+fn test_state_check_schema_version_ok() {
+    let state = IndexState::new(PathBuf::from("/test/repo"));
+    assert!(state.check_schema_version().is_ok());
+}
+
+#[test]
+fn test_state_check_schema_version_mismatch() {
+    let mut state = IndexState::new(PathBuf::from("/test/repo"));
+    state.schema_version = 999;
+    assert!(state.check_schema_version().is_err());
+}
+
+#[test]
+fn test_state_exists_false() {
+    let tmp = TempDir::new().unwrap();
+    let ci_dir = tmp.path().join(".commandindex");
+    assert!(!IndexState::exists(&ci_dir));
+}
+
+#[test]
+fn test_state_exists_true() {
+    let tmp = TempDir::new().unwrap();
+    let ci_dir = tmp.path().join(".commandindex");
+
+    let state = IndexState::new(PathBuf::from("/test/repo"));
+    state.save(&ci_dir).unwrap();
+
+    assert!(IndexState::exists(&ci_dir));
+}
+
+#[test]
+fn test_state_touch_updates_timestamp() {
+    let mut state = IndexState::new(PathBuf::from("/test/repo"));
+    let original = state.last_updated_at;
+
+    // Small delay to ensure timestamp differs
+    std::thread::sleep(std::time::Duration::from_millis(10));
+    state.touch();
+
+    assert!(state.last_updated_at >= original);
+}
+
+#[test]
+fn test_state_load_nonexistent() {
+    let tmp = TempDir::new().unwrap();
+    let ci_dir = tmp.path().join(".commandindex");
+    assert!(IndexState::load(&ci_dir).is_err());
+}
+
+// === Manifest tests ===
+
+#[test]
+fn test_manifest_new() {
+    let manifest = Manifest::new();
+    assert!(manifest.files.is_empty());
+    assert_eq!(manifest.file_count(), 0);
+}
+
+#[test]
+fn test_manifest_add_entry() {
+    let mut manifest = Manifest::new();
+    manifest.add_entry(FileEntry {
+        path: "docs/auth.md".to_string(),
+        hash: "sha256:abc123".to_string(),
+        last_modified: Utc::now(),
+        sections: 5,
+    });
+    assert_eq!(manifest.file_count(), 1);
+}
+
+#[test]
+fn test_manifest_find_by_path() {
+    let mut manifest = Manifest::new();
+    manifest.add_entry(FileEntry {
+        path: "docs/auth.md".to_string(),
+        hash: "sha256:abc123".to_string(),
+        last_modified: Utc::now(),
+        sections: 5,
+    });
+    manifest.add_entry(FileEntry {
+        path: "docs/api.md".to_string(),
+        hash: "sha256:def456".to_string(),
+        last_modified: Utc::now(),
+        sections: 3,
+    });
+
+    let entry = manifest.find_by_path("docs/auth.md");
+    assert!(entry.is_some());
+    assert_eq!(entry.unwrap().sections, 5);
+
+    assert!(manifest.find_by_path("nonexistent.md").is_none());
+}
+
+#[test]
+fn test_manifest_save_and_load() {
+    let tmp = TempDir::new().unwrap();
+    let ci_dir = tmp.path().join(".commandindex");
+
+    let mut manifest = Manifest::new();
+    manifest.add_entry(FileEntry {
+        path: "docs/auth.md".to_string(),
+        hash: "sha256:abc123".to_string(),
+        last_modified: Utc::now(),
+        sections: 5,
+    });
+
+    manifest.save(&ci_dir).unwrap();
+
+    let loaded = Manifest::load(&ci_dir).unwrap();
+    assert_eq!(loaded.file_count(), 1);
+    assert_eq!(loaded.files[0].path, "docs/auth.md");
+    assert_eq!(loaded.files[0].hash, "sha256:abc123");
+}
+
+#[test]
+fn test_manifest_load_nonexistent() {
+    let tmp = TempDir::new().unwrap();
+    let ci_dir = tmp.path().join(".commandindex");
+    assert!(Manifest::load(&ci_dir).is_err());
+}
+
+// === File hash tests ===
+
+#[test]
+fn test_compute_file_hash() {
+    let tmp = TempDir::new().unwrap();
+    let file_path = tmp.path().join("test.md");
+    fs::write(&file_path, "Hello, World!").unwrap();
+
+    let hash = manifest::compute_file_hash(&file_path).unwrap();
+    assert!(hash.starts_with("sha256:"));
+    assert!(hash.len() > 10);
+}
+
+#[test]
+fn test_compute_file_hash_deterministic() {
+    let tmp = TempDir::new().unwrap();
+    let file_path = tmp.path().join("test.md");
+    fs::write(&file_path, "Same content").unwrap();
+
+    let hash1 = manifest::compute_file_hash(&file_path).unwrap();
+    let hash2 = manifest::compute_file_hash(&file_path).unwrap();
+    assert_eq!(hash1, hash2);
+}
+
+#[test]
+fn test_compute_file_hash_different_content() {
+    let tmp = TempDir::new().unwrap();
+
+    let file1 = tmp.path().join("file1.md");
+    let file2 = tmp.path().join("file2.md");
+    fs::write(&file1, "Content A").unwrap();
+    fs::write(&file2, "Content B").unwrap();
+
+    let hash1 = manifest::compute_file_hash(&file1).unwrap();
+    let hash2 = manifest::compute_file_hash(&file2).unwrap();
+    assert_ne!(hash1, hash2);
+}
+
+#[test]
+fn test_compute_file_hash_nonexistent() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("nonexistent.md");
+    assert!(manifest::compute_file_hash(&path).is_err());
+}


### PR DESCRIPTION
## Summary
- state.json読み書きとスキーマバージョン管理を実装
- manifest.jsonによるファイル一覧・ハッシュ管理を実装
- SHA-256ファイルハッシュ計算と整合性チェック機能を実装

## Test plan
- [x] IndexState作成・保存・読込テスト
- [x] スキーマバージョンチェックテスト（正常/不一致）
- [x] インデックス存在判定テスト
- [x] Manifest CRUD テスト
- [x] ファイルハッシュ計算テスト（決定性、異なるコンテンツ）
- [x] エラーケース（存在しないファイル）テスト
- [x] cargo clippy / fmt / test 全パス

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)