### PR TITLE
feat: cleanコマンド実装

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,7 @@ tests/
 src/
 ├── main.rs              # エントリポイント
 ├── lib.rs               # モジュール宣言
-├── cli/                 # CLI サブコマンド
+├── cli/                 # CLI サブコマンド（index, clean）
 ├── parser/              # Markdown / ソースコード解析
 ├── indexer/             # tantivy / SQLite インデックス操作
 ├── search/              # 検索ロジック

--- a/src/cli/clean.rs
+++ b/src/cli/clean.rs
@@ -1,0 +1,65 @@
+use std::fmt;
+use std::path::Path;
+
+#[derive(Debug)]
+pub enum CleanError {
+    Io(std::io::Error),
+    SymlinkDetected,
+}
+
+impl fmt::Display for CleanError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CleanError::Io(e) => write!(f, "failed to remove .commandindex/: {e}"),
+            CleanError::SymlinkDetected => {
+                write!(f, ".commandindex/ is a symbolic link — refusing to delete")
+            }
+        }
+    }
+}
+
+impl std::error::Error for CleanError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            CleanError::Io(e) => Some(e),
+            CleanError::SymlinkDetected => None,
+        }
+    }
+}
+
+impl From<std::io::Error> for CleanError {
+    fn from(e: std::io::Error) -> Self {
+        CleanError::Io(e)
+    }
+}
+
+pub enum CleanResult {
+    Removed,
+    NotFound,
+}
+
+pub fn run(path: &Path) -> Result<CleanResult, CleanError> {
+    let commandindex_dir = path.join(crate::INDEX_DIR_NAME);
+
+    // Symlink safety check
+    match std::fs::symlink_metadata(&commandindex_dir) {
+        Ok(metadata) => {
+            if metadata.file_type().is_symlink() {
+                return Err(CleanError::SymlinkDetected);
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(CleanResult::NotFound);
+        }
+        Err(e) => {
+            return Err(CleanError::Io(e));
+        }
+    }
+
+    // TOCTOU-safe: attempt deletion directly
+    match std::fs::remove_dir_all(&commandindex_dir) {
+        Ok(()) => Ok(CleanResult::Removed),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(CleanResult::NotFound),
+        Err(e) => Err(CleanError::Io(e)),
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,1 +1,2 @@
+pub mod clean;
 pub mod index;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,3 +6,5 @@ pub mod indexer;
 pub mod parser;
 // pub mod search;
 pub mod output;
+
+pub const INDEX_DIR_NAME: &str = ".commandindex";

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,11 @@ enum Commands {
     /// Show index status
     Status,
     /// Remove index and prepare for rebuild
-    Clean,
+    Clean {
+        /// Target directory containing .commandindex/
+        #[arg(long, default_value = ".")]
+        path: PathBuf,
+    },
 }
 
 fn main() {
@@ -71,10 +75,21 @@ fn main() {
             eprintln!("Error: `status` command is not yet implemented. Coming in Phase 1.");
             1
         }
-        Commands::Clean => {
-            eprintln!("Error: `clean` command is not yet implemented. Coming in Phase 1.");
-            1
-        }
+        Commands::Clean { path } => match commandindex::cli::clean::run(&path) {
+            Ok(commandindex::cli::clean::CleanResult::Removed) => {
+                println!("Removed index at .commandindex/");
+                println!("Run `commandindex index` to rebuild.");
+                0
+            }
+            Ok(commandindex::cli::clean::CleanResult::NotFound) => {
+                println!("No index found. Nothing to clean.");
+                0
+            }
+            Err(e) => {
+                eprintln!("Error: {e}");
+                1
+            }
+        },
     };
 
     process::exit(exit_code);

--- a/tests/cli_args.rs
+++ b/tests/cli_args.rs
@@ -70,15 +70,6 @@ fn status_subcommand_exits_with_not_implemented() {
 }
 
 #[test]
-fn clean_subcommand_exits_with_not_implemented() {
-    common::cmd()
-        .arg("clean")
-        .assert()
-        .failure()
-        .stderr(predicate::str::contains("not yet implemented"));
-}
-
-#[test]
 fn search_requires_query_argument() {
     common::cmd()
         .arg("search")

--- a/tests/cli_clean.rs
+++ b/tests/cli_clean.rs
@@ -1,0 +1,89 @@
+mod common;
+use predicates::prelude::*;
+
+#[test]
+fn clean_removes_commandindex_directory() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    // First, create an index
+    common::cmd()
+        .args(["index", "--path", dir.path().to_str().unwrap()])
+        .assert()
+        .success();
+    assert!(dir.path().join(".commandindex").is_dir());
+
+    // Then clean
+    common::cmd()
+        .args(["clean", "--path", dir.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Removed index at .commandindex/"));
+
+    assert!(!dir.path().join(".commandindex").exists());
+}
+
+#[test]
+fn clean_with_no_index_succeeds() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    common::cmd()
+        .args(["clean", "--path", dir.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "No index found. Nothing to clean.",
+        ));
+}
+
+#[test]
+fn clean_with_path_option() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    common::cmd()
+        .args(["index", "--path", dir.path().to_str().unwrap()])
+        .assert()
+        .success();
+
+    common::cmd()
+        .args(["clean", "--path", dir.path().to_str().unwrap()])
+        .assert()
+        .success();
+
+    assert!(!dir.path().join(".commandindex").exists());
+}
+
+#[test]
+fn clean_default_path_is_current_dir() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    // Just verify clean runs without error on a dir with no index
+    common::cmd()
+        .current_dir(dir.path())
+        .arg("clean")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No index found"));
+}
+
+#[test]
+fn clean_then_reindex_succeeds() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    // Create a markdown file for indexing
+    std::fs::write(dir.path().join("test.md"), "# Test\nContent").unwrap();
+
+    // index -> clean -> index round trip
+    common::cmd()
+        .args(["index", "--path", dir.path().to_str().unwrap()])
+        .assert()
+        .success();
+
+    common::cmd()
+        .args(["clean", "--path", dir.path().to_str().unwrap()])
+        .assert()
+        .success();
+
+    assert!(!dir.path().join(".commandindex").exists());
+
+    common::cmd()
+        .args(["index", "--path", dir.path().to_str().unwrap()])
+        .assert()
+        .success();
+
+    assert!(dir.path().join(".commandindex").is_dir());
+}


### PR DESCRIPTION
## Summary
- `commandindex clean` コマンドを実装（`.commandindex/` ディレクトリ削除）
- CleanError enum による構造化エラー処理
- インデックス未作成時の案内メッセージ表示
- E2Eテスト追加

## Test plan
- [ ] `commandindex clean` でインデックスが削除されることを確認
- [ ] インデックス未作成時にエラーにならないことを確認
- [ ] `cargo test --all` 全パス
- [ ] `cargo clippy --all-targets -- -D warnings` 警告0件

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)