### PR TITLE
feat: searchコマンド実装（全文検索・フィルタ）

### DIFF
--- a/src/cli/index.rs
+++ b/src/cli/index.rs
@@ -96,7 +96,7 @@ fn section_to_doc(
     file_path: &str,
     frontmatter: Option<&crate::parser::Frontmatter>,
 ) -> SectionDoc {
-    let tags = frontmatter.map(|fm| fm.tags.join(", ")).unwrap_or_default();
+    let tags = frontmatter.map(|fm| fm.tags.join(" ")).unwrap_or_default();
 
     SectionDoc {
         path: file_path.to_string(),
@@ -141,8 +141,8 @@ pub fn run(path: &Path) -> Result<IndexSummary, IndexError> {
     }
 
     // 5. Remove existing tantivy directory if present
-    let commandindex_dir = path.join(".commandindex");
-    let tantivy_dir = commandindex_dir.join("tantivy");
+    let commandindex_dir = crate::indexer::commandindex_dir(path);
+    let tantivy_dir = crate::indexer::index_dir(path);
     if tantivy_dir.exists() {
         std::fs::remove_dir_all(&tantivy_dir)?;
     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,3 +1,4 @@
 pub mod clean;
 pub mod index;
+pub mod search;
 pub mod status;

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -1,0 +1,67 @@
+use std::fmt;
+use std::path::Path;
+
+use crate::indexer::reader::{IndexReaderWrapper, ReaderError, SearchFilters, SearchOptions};
+use crate::output::{self, OutputError, OutputFormat};
+
+#[derive(Debug)]
+pub enum SearchError {
+    IndexNotFound,
+    Reader(ReaderError),
+    Output(OutputError),
+}
+
+impl fmt::Display for SearchError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SearchError::IndexNotFound => {
+                write!(f, "Index not found. Run `commandindex index` first.")
+            }
+            SearchError::Reader(e) => write!(f, "{e}"),
+            SearchError::Output(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for SearchError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            SearchError::IndexNotFound => None,
+            SearchError::Reader(e) => Some(e),
+            SearchError::Output(e) => Some(e),
+        }
+    }
+}
+
+impl From<ReaderError> for SearchError {
+    fn from(e: ReaderError) -> Self {
+        SearchError::Reader(e)
+    }
+}
+
+impl From<OutputError> for SearchError {
+    fn from(e: OutputError) -> Self {
+        SearchError::Output(e)
+    }
+}
+
+pub fn run(
+    options: &SearchOptions,
+    filters: &SearchFilters,
+    format: OutputFormat,
+) -> Result<(), SearchError> {
+    let tantivy_dir = crate::indexer::index_dir(Path::new("."));
+    if !tantivy_dir.exists() {
+        return Err(SearchError::IndexNotFound);
+    }
+    let reader = IndexReaderWrapper::open(&tantivy_dir)?;
+    let results = reader.search_with_options(options, filters)?;
+    if results.is_empty() {
+        eprintln!("No results found.");
+        return Ok(());
+    }
+    let stdout = std::io::stdout();
+    let mut handle = stdout.lock();
+    output::format_results(&results, format, &mut handle)?;
+    Ok(())
+}

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -3,3 +3,18 @@ pub mod reader;
 pub mod schema;
 pub mod state;
 pub mod writer;
+
+use std::path::{Path, PathBuf};
+
+const COMMANDINDEX_DIR: &str = ".commandindex";
+const TANTIVY_DIR: &str = "tantivy";
+
+/// `.commandindex/tantivy` ディレクトリのパスを返す
+pub fn index_dir(base_path: &Path) -> PathBuf {
+    base_path.join(COMMANDINDEX_DIR).join(TANTIVY_DIR)
+}
+
+/// `.commandindex` ディレクトリのパスを返す
+pub fn commandindex_dir(base_path: &Path) -> PathBuf {
+    base_path.join(COMMANDINDEX_DIR)
+}

--- a/src/indexer/reader.rs
+++ b/src/indexer/reader.rs
@@ -1,11 +1,28 @@
 use std::fmt;
 use std::path::Path;
 use tantivy::collector::TopDocs;
-use tantivy::query::QueryParser;
+use tantivy::query::{BooleanQuery, Occur, QueryParser};
 use tantivy::schema::Value;
 use tantivy::{Index, ReloadPolicy};
 
 use crate::indexer::schema::IndexSchema;
+
+/// Post-filter oversampling factor: fetch N times the limit when post-filters are active
+const OVERSAMPLING_FACTOR: usize = 5;
+
+#[derive(Debug, Clone)]
+pub struct SearchOptions {
+    pub query: String,
+    pub tag: Option<String>,
+    pub heading: Option<String>,
+    pub limit: usize,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct SearchFilters {
+    pub path_prefix: Option<String>,
+    pub file_type: Option<String>,
+}
 
 #[derive(Debug)]
 pub enum ReaderError {
@@ -77,6 +94,21 @@ impl IndexReaderWrapper {
 
     /// クエリで検索し、上位N件を返す
     pub fn search(&self, query_str: &str, limit: usize) -> Result<Vec<SearchResult>, ReaderError> {
+        let options = SearchOptions {
+            query: query_str.to_string(),
+            tag: None,
+            heading: None,
+            limit,
+        };
+        self.search_with_options(&options, &SearchFilters::default())
+    }
+
+    /// オプション付き検索
+    pub fn search_with_options(
+        &self,
+        options: &SearchOptions,
+        filters: &SearchFilters,
+    ) -> Result<Vec<SearchResult>, ReaderError> {
         let reader = self
             .index
             .reader_builder()
@@ -84,58 +116,100 @@ impl IndexReaderWrapper {
             .try_into()?;
         let searcher = reader.searcher();
 
-        let query_parser = QueryParser::for_index(
+        // Build BooleanQuery with sub-queries
+        let mut sub_queries: Vec<(Occur, Box<dyn tantivy::query::Query>)> = Vec::new();
+
+        // Main query across heading, body, tags
+        let main_parser = QueryParser::for_index(
             &self.index,
             vec![self.schema.heading, self.schema.body, self.schema.tags],
         );
+        let main_query = main_parser.parse_query(&options.query)?;
+        sub_queries.push((Occur::Must, main_query));
 
-        let query = query_parser.parse_query(query_str)?;
-        let top_docs = searcher.search(&query, &TopDocs::with_limit(limit))?;
+        // Tag filter (search only in tags field)
+        if let Some(ref tag) = options.tag {
+            let tag_parser = QueryParser::for_index(&self.index, vec![self.schema.tags]);
+            let tag_query = tag_parser.parse_query(tag)?;
+            sub_queries.push((Occur::Must, tag_query));
+        }
+
+        // Heading filter (search only in heading field)
+        if let Some(ref heading) = options.heading {
+            let heading_parser = QueryParser::for_index(&self.index, vec![self.schema.heading]);
+            let heading_query = heading_parser.parse_query(heading)?;
+            sub_queries.push((Occur::Must, heading_query));
+        }
+
+        // Determine fetch limit with oversampling if post-filters are active
+        let has_post_filter = filters.path_prefix.is_some() || filters.file_type.is_some();
+        let fetch_limit = if has_post_filter {
+            options.limit.saturating_mul(OVERSAMPLING_FACTOR)
+        } else {
+            options.limit
+        };
+
+        let boolean_query = BooleanQuery::new(sub_queries);
+        let top_docs = searcher.search(&boolean_query, &TopDocs::with_limit(fetch_limit))?;
 
         let mut results = Vec::new();
         for (score, doc_address) in top_docs {
             let doc: tantivy::TantivyDocument = searcher.doc(doc_address)?;
+            let result = self.doc_to_search_result(&doc, score);
 
-            let path = doc
-                .get_first(self.schema.path)
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string();
-            let heading = doc
-                .get_first(self.schema.heading)
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string();
-            let body = doc
-                .get_first(self.schema.body)
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string();
-            let tags = doc
-                .get_first(self.schema.tags)
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string();
-            let heading_level = doc
-                .get_first(self.schema.heading_level)
-                .and_then(|v| v.as_u64())
-                .unwrap_or(0);
-            let line_start = doc
-                .get_first(self.schema.line_start)
-                .and_then(|v| v.as_u64())
-                .unwrap_or(0);
+            // Post-filter: path prefix
+            if let Some(ref prefix) = filters.path_prefix
+                && !result.path.starts_with(prefix.as_str())
+            {
+                continue;
+            }
 
-            results.push(SearchResult {
-                path,
-                heading,
-                body,
-                tags,
-                heading_level,
-                line_start,
-                score,
-            });
+            // Post-filter: file type
+            if let Some(ref file_type) = filters.file_type
+                && !matches_file_type(&result.path, file_type)
+            {
+                continue;
+            }
+
+            results.push(result);
+            if results.len() >= options.limit {
+                break;
+            }
         }
 
         Ok(results)
+    }
+
+    /// TantivyDocument から SearchResult を生成するヘルパー
+    fn doc_to_search_result(&self, doc: &tantivy::TantivyDocument, score: f32) -> SearchResult {
+        SearchResult {
+            path: Self::get_text(doc, self.schema.path),
+            heading: Self::get_text(doc, self.schema.heading),
+            body: Self::get_text(doc, self.schema.body),
+            tags: Self::get_text(doc, self.schema.tags),
+            heading_level: Self::get_u64(doc, self.schema.heading_level),
+            line_start: Self::get_u64(doc, self.schema.line_start),
+            score,
+        }
+    }
+
+    /// ドキュメントからテキストフィールドを取得する
+    fn get_text(doc: &tantivy::TantivyDocument, field: tantivy::schema::Field) -> String {
+        doc.get_first(field)
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string()
+    }
+
+    /// ドキュメントからu64フィールドを取得する
+    fn get_u64(doc: &tantivy::TantivyDocument, field: tantivy::schema::Field) -> u64 {
+        doc.get_first(field).and_then(|v| v.as_u64()).unwrap_or(0)
+    }
+}
+
+fn matches_file_type(path: &str, file_type: &str) -> bool {
+    match file_type {
+        "markdown" => path.ends_with(".md"),
+        _ => false,
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,7 @@
 // CommandIndex library root
-//
-// Module declarations will be added as implementation progresses:
 pub mod cli;
 pub mod indexer;
-pub mod parser;
-// pub mod search;
 pub mod output;
+pub mod parser;
 
 pub const INDEX_DIR_NAME: &str = ".commandindex";

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,21 @@ enum Commands {
         /// Output format (human, json, path)
         #[arg(long, value_enum, default_value_t = commandindex::output::OutputFormat::Human)]
         format: commandindex::output::OutputFormat,
+        /// Filter by tag
+        #[arg(long)]
+        tag: Option<String>,
+        /// Filter by path prefix
+        #[arg(long)]
+        path: Option<String>,
+        /// Filter by file type (e.g. "markdown")
+        #[arg(long = "type")]
+        file_type: Option<String>,
+        /// Filter by heading
+        #[arg(long)]
+        heading: Option<String>,
+        /// Maximum number of results (1-1000)
+        #[arg(long, default_value_t = 20)]
+        limit: usize,
     },
     /// Incrementally update the index
     Update,
@@ -68,11 +83,31 @@ fn main() {
             }
         },
         Commands::Search {
-            query: _,
-            format: _,
+            query,
+            format,
+            tag,
+            path,
+            file_type,
+            heading,
+            limit,
         } => {
-            eprintln!("Error: `search` command is not yet implemented. Coming in Phase 1.");
-            1
+            let options = commandindex::indexer::reader::SearchOptions {
+                query,
+                tag,
+                heading,
+                limit: limit.min(1000),
+            };
+            let filters = commandindex::indexer::reader::SearchFilters {
+                path_prefix: path,
+                file_type,
+            };
+            match commandindex::cli::search::run(&options, &filters, format) {
+                Ok(()) => 0,
+                Err(e) => {
+                    eprintln!("Error: {e}");
+                    1
+                }
+            }
         }
         Commands::Update => {
             eprintln!("Error: `update` command is not yet implemented. Coming in Phase 2.");

--- a/tests/cli_args.rs
+++ b/tests/cli_args.rs
@@ -43,12 +43,42 @@ fn index_subcommand_accepts_path_option() {
 }
 
 #[test]
-fn search_subcommand_exits_with_not_implemented() {
+fn search_without_index_shows_error() {
+    // Run search from a temp directory where no index exists
+    let tmp = tempfile::tempdir().expect("create temp dir");
     common::cmd()
+        .current_dir(tmp.path())
         .args(["search", "test query"])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("not yet implemented"));
+        .stderr(predicate::str::contains("Index not found"));
+}
+
+#[test]
+fn search_with_all_options_accepted() {
+    // Verify all options are accepted by clap (even if search fails due to no index)
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    common::cmd()
+        .current_dir(tmp.path())
+        .args([
+            "search",
+            "test query",
+            "--format",
+            "json",
+            "--tag",
+            "rust",
+            "--path",
+            "docs/",
+            "--type",
+            "markdown",
+            "--heading",
+            "Setup",
+            "--limit",
+            "5",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Index not found"));
 }
 
 #[test]
@@ -59,7 +89,6 @@ fn update_subcommand_exits_with_not_implemented() {
         .failure()
         .stderr(predicate::str::contains("not yet implemented"));
 }
-
 
 #[test]
 fn search_requires_query_argument() {

--- a/tests/indexer_tantivy.rs
+++ b/tests/indexer_tantivy.rs
@@ -1,4 +1,4 @@
-use commandindex::indexer::reader::IndexReaderWrapper;
+use commandindex::indexer::reader::{IndexReaderWrapper, SearchFilters, SearchOptions};
 use commandindex::indexer::writer::{IndexWriterWrapper, SectionDoc};
 use tempfile::TempDir;
 
@@ -233,5 +233,180 @@ fn test_commandindex_tantivy_path() {
 
     let reader = IndexReaderWrapper::open(&index_dir).unwrap();
     let results = reader.search("Title", 10).unwrap();
+    assert!(!results.is_empty());
+}
+
+// === search_with_options tests ===
+
+fn build_multi_doc_index() -> (IndexReaderWrapper, tempfile::TempDir) {
+    let tmp = TempDir::new().unwrap();
+    let index_dir = tmp.path().join("tantivy");
+
+    {
+        let mut writer = IndexWriterWrapper::open(&index_dir).unwrap();
+        writer
+            .add_section(&SectionDoc {
+                path: "docs/auth.md".to_string(),
+                heading: "Authentication".to_string(),
+                body: "User authentication and authorization module.".to_string(),
+                tags: "auth security".to_string(),
+                heading_level: 1,
+                line_start: 1,
+            })
+            .unwrap();
+        writer
+            .add_section(&SectionDoc {
+                path: "docs/api.md".to_string(),
+                heading: "API Reference".to_string(),
+                body: "REST API endpoints for the application.".to_string(),
+                tags: "api http".to_string(),
+                heading_level: 1,
+                line_start: 1,
+            })
+            .unwrap();
+        writer
+            .add_section(&SectionDoc {
+                path: "src/main.rs".to_string(),
+                heading: "Main Entry".to_string(),
+                body: "The main entry point for the authentication service.".to_string(),
+                tags: "auth rust".to_string(),
+                heading_level: 1,
+                line_start: 1,
+            })
+            .unwrap();
+        writer
+            .add_section(&SectionDoc {
+                path: "guides/setup.md".to_string(),
+                heading: "Setup Guide".to_string(),
+                body: "How to set up the development environment.".to_string(),
+                tags: "guide setup".to_string(),
+                heading_level: 2,
+                line_start: 5,
+            })
+            .unwrap();
+        writer.commit().unwrap();
+    }
+
+    let reader = IndexReaderWrapper::open(&index_dir).unwrap();
+    (reader, tmp)
+}
+
+#[test]
+fn test_search_with_options_tag_filter() {
+    let (reader, _tmp) = build_multi_doc_index();
+    let options = SearchOptions {
+        query: "authentication".to_string(),
+        tag: Some("security".to_string()),
+        heading: None,
+        limit: 10,
+    };
+    let filters = SearchFilters {
+        path_prefix: None,
+        file_type: None,
+    };
+    let results = reader.search_with_options(&options, &filters).unwrap();
+    assert!(!results.is_empty());
+    // Only the doc with "security" tag should match
+    assert!(results.iter().all(|r| r.tags.contains("security")));
+}
+
+#[test]
+fn test_search_with_options_heading_filter() {
+    let (reader, _tmp) = build_multi_doc_index();
+    let options = SearchOptions {
+        query: "authentication".to_string(),
+        tag: None,
+        heading: Some("Authentication".to_string()),
+        limit: 10,
+    };
+    let filters = SearchFilters {
+        path_prefix: None,
+        file_type: None,
+    };
+    let results = reader.search_with_options(&options, &filters).unwrap();
+    assert!(!results.is_empty());
+    assert!(results.iter().all(|r| r.heading.contains("Authentication")));
+}
+
+#[test]
+fn test_search_with_options_path_prefix_filter() {
+    let (reader, _tmp) = build_multi_doc_index();
+    let options = SearchOptions {
+        query: "authentication".to_string(),
+        tag: None,
+        heading: None,
+        limit: 10,
+    };
+    let filters = SearchFilters {
+        path_prefix: Some("docs/".to_string()),
+        file_type: None,
+    };
+    let results = reader.search_with_options(&options, &filters).unwrap();
+    assert!(!results.is_empty());
+    assert!(results.iter().all(|r| r.path.starts_with("docs/")));
+}
+
+#[test]
+fn test_search_with_options_file_type_filter() {
+    let (reader, _tmp) = build_multi_doc_index();
+    let options = SearchOptions {
+        query: "authentication".to_string(),
+        tag: None,
+        heading: None,
+        limit: 10,
+    };
+    let filters = SearchFilters {
+        path_prefix: None,
+        file_type: Some("markdown".to_string()),
+    };
+    let results = reader.search_with_options(&options, &filters).unwrap();
+    assert!(!results.is_empty());
+    assert!(results.iter().all(|r| r.path.ends_with(".md")));
+}
+
+#[test]
+fn test_search_with_options_combined_filters() {
+    let (reader, _tmp) = build_multi_doc_index();
+    let options = SearchOptions {
+        query: "authentication".to_string(),
+        tag: Some("auth".to_string()),
+        heading: None,
+        limit: 10,
+    };
+    let filters = SearchFilters {
+        path_prefix: Some("docs/".to_string()),
+        file_type: Some("markdown".to_string()),
+    };
+    let results = reader.search_with_options(&options, &filters).unwrap();
+    assert!(!results.is_empty());
+    assert!(
+        results
+            .iter()
+            .all(|r| r.path.starts_with("docs/") && r.path.ends_with(".md"))
+    );
+}
+
+#[test]
+fn test_search_with_options_limit() {
+    let (reader, _tmp) = build_multi_doc_index();
+    let options = SearchOptions {
+        query: "authentication".to_string(),
+        tag: None,
+        heading: None,
+        limit: 1,
+    };
+    let filters = SearchFilters {
+        path_prefix: None,
+        file_type: None,
+    };
+    let results = reader.search_with_options(&options, &filters).unwrap();
+    assert!(results.len() <= 1);
+}
+
+#[test]
+fn test_search_with_options_delegates_from_search() {
+    // Verify that search() still works as a wrapper
+    let (reader, _tmp) = build_multi_doc_index();
+    let results = reader.search("authentication", 10).unwrap();
     assert!(!results.is_empty());
 }


### PR DESCRIPTION
## Summary
- `commandindex search` コマンドを実装（tantivy BM25全文検索）
- --tag, --path, --type, --heading フィルタ（AND条件結合）
- --format (human/json/path) 出力形式切り替え
- --limit 結果件数制限（デフォルト20）
- search_with_options API追加
- E2E・統合テスト7件新規追加

## Test plan
- [ ] 全文検索（日本語・英語）の動作確認
- [ ] 各フィルタオプションの動作確認
- [ ] 複数フィルタの組み合わせ（AND条件）確認
- [ ] `cargo test --all` 全パス
- [ ] `cargo clippy --all-targets -- -D warnings` 警告0件

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)