### PR TITLE
feat: 差分検知エンジン実装

### DIFF
--- a/src/indexer/diff.rs
+++ b/src/indexer/diff.rs
@@ -1,0 +1,168 @@
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use walkdir::WalkDir;
+
+use super::manifest::{Manifest, compute_file_hash, to_relative_path_string};
+use crate::parser::ignore::IgnoreFilter;
+
+/// 差分検知で発生しうるエラー
+#[derive(Debug)]
+pub enum DiffError {
+    Io(std::io::Error),
+}
+
+impl fmt::Display for DiffError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DiffError::Io(e) => write!(f, "IO error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for DiffError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            DiffError::Io(e) => Some(e),
+        }
+    }
+}
+
+impl From<std::io::Error> for DiffError {
+    fn from(e: std::io::Error) -> Self {
+        DiffError::Io(e)
+    }
+}
+
+/// ファイルスキャン結果
+pub struct ScanResult {
+    /// 対象ファイルの絶対パス一覧
+    pub files: Vec<PathBuf>,
+    /// 無視されたファイル数
+    pub ignored_count: u64,
+}
+
+/// 差分検知結果
+pub struct DiffResult {
+    /// 追加されたファイル（絶対パス）
+    pub added: Vec<PathBuf>,
+    /// 変更されたファイル（絶対パス）
+    pub modified: Vec<PathBuf>,
+    /// 削除されたファイル（相対パス）
+    pub deleted: Vec<PathBuf>,
+    /// 変更なしファイル数
+    pub unchanged: usize,
+}
+
+impl DiffResult {
+    /// 変更がないかどうかを返す（added, modified, deleted が全て空）
+    pub fn is_empty(&self) -> bool {
+        self.added.is_empty() && self.modified.is_empty() && self.deleted.is_empty()
+    }
+}
+
+/// 指定ディレクトリ配下のファイルをスキャンし、拡張子フィルタと IgnoreFilter を適用する
+pub fn scan_files(
+    base_path: &Path,
+    ignore_filter: &IgnoreFilter,
+    extensions: &[&str],
+) -> Result<ScanResult, std::io::Error> {
+    let mut files = Vec::new();
+    let mut ignored_count: u64 = 0;
+
+    for entry in WalkDir::new(base_path)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().is_file())
+    {
+        let path = entry.path();
+
+        // 拡張子フィルタ
+        let ext_match = match path.extension().and_then(|e| e.to_str()) {
+            Some(ext) => extensions.contains(&ext),
+            None => false,
+        };
+        if !ext_match {
+            continue;
+        }
+
+        // IgnoreFilter 適用（相対パスで判定）
+        let rel = path.strip_prefix(base_path).unwrap_or(path);
+        if ignore_filter.is_ignored(rel) {
+            ignored_count += 1;
+            continue;
+        }
+
+        files.push(path.to_path_buf());
+    }
+
+    Ok(ScanResult {
+        files,
+        ignored_count,
+    })
+}
+
+/// マニフェストと現在のファイル一覧を比較し、差分を検出する
+pub fn detect_changes(
+    base_path: &Path,
+    manifest: &Manifest,
+    current_files: &[PathBuf],
+) -> Result<DiffResult, DiffError> {
+    // 1. manifest.files → HashMap<相対パス, &FileEntry>
+    let manifest_map: HashMap<&str, _> = manifest
+        .files
+        .iter()
+        .map(|entry| (entry.path.as_str(), entry))
+        .collect();
+
+    let mut visited: HashSet<String> = HashSet::new();
+    let mut added = Vec::new();
+    let mut modified = Vec::new();
+    let mut deleted = Vec::new();
+    let mut unchanged: usize = 0;
+
+    // 2. current_files ごとに判定
+    for abs_path in current_files {
+        let rel = to_relative_path_string(abs_path, base_path);
+        visited.insert(rel.clone());
+
+        match manifest_map.get(rel.as_str()) {
+            None => {
+                // マニフェストに存在しない → 追加
+                added.push(abs_path.clone());
+            }
+            Some(entry) => {
+                // ハッシュ比較
+                match compute_file_hash(abs_path) {
+                    Ok(hash) => {
+                        if hash != entry.hash {
+                            modified.push(abs_path.clone());
+                        } else {
+                            unchanged += 1;
+                        }
+                    }
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                        // TOCTOU対策: スキャン後にファイルが消えた場合は deleted 扱い
+                        deleted.push(PathBuf::from(&rel));
+                    }
+                    Err(e) => return Err(DiffError::Io(e)),
+                }
+            }
+        }
+    }
+
+    // 3. manifest にあるが visited にないもの → deleted
+    for entry in &manifest.files {
+        if !visited.contains(&entry.path) {
+            deleted.push(PathBuf::from(&entry.path));
+        }
+    }
+
+    Ok(DiffResult {
+        added,
+        modified,
+        deleted,
+        unchanged,
+    })
+}

--- a/src/indexer/manifest.rs
+++ b/src/indexer/manifest.rs
@@ -98,6 +98,26 @@ impl Manifest {
     pub fn find_by_path(&self, path: &str) -> Option<&FileEntry> {
         self.files.iter().find(|e| e.path == path)
     }
+
+    /// manifest.json を読み込む。ファイルが存在しない場合は空の Manifest を返す。
+    pub fn load_or_default(commandindex_dir: &Path) -> Result<Self, ManifestError> {
+        match Self::load(commandindex_dir) {
+            Ok(m) => Ok(m),
+            Err(ManifestError::Io(ref e)) if e.kind() == std::io::ErrorKind::NotFound => {
+                Ok(Self::new())
+            }
+            Err(e) => Err(e),
+        }
+    }
+}
+
+/// 絶対パスを base_path からの相対パス文字列に変換する
+pub fn to_relative_path_string(absolute: &Path, base: &Path) -> String {
+    absolute
+        .strip_prefix(base)
+        .unwrap_or(absolute)
+        .to_string_lossy()
+        .to_string()
 }
 
 /// ファイルのSHA-256ハッシュを計算する

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -1,3 +1,4 @@
+pub mod diff;
 pub mod manifest;
 pub mod reader;
 pub mod schema;
@@ -8,6 +9,10 @@ use std::path::{Path, PathBuf};
 
 const COMMANDINDEX_DIR: &str = ".commandindex";
 const TANTIVY_DIR: &str = "tantivy";
+
+/// 対象ファイル拡張子（Phase 1: Markdown のみ）
+// TODO: Phase 2 で cli/index.rs のハードコードをこの定数に統合すること
+pub const SUPPORTED_EXTENSIONS: &[&str] = &["md"];
 
 /// `.commandindex/tantivy` ディレクトリのパスを返す
 pub fn index_dir(base_path: &Path) -> PathBuf {

--- a/tests/diff_detection.rs
+++ b/tests/diff_detection.rs
@@ -1,0 +1,270 @@
+mod common;
+
+use std::fs;
+use std::path::Path;
+use tempfile::TempDir;
+
+use commandindex::indexer::diff::{DiffResult, detect_changes, scan_files};
+use commandindex::indexer::manifest::{
+    FileEntry, Manifest, compute_file_hash, to_relative_path_string,
+};
+use commandindex::parser::ignore::IgnoreFilter;
+
+// Verify SUPPORTED_EXTENSIONS is accessible
+const _: &[&str] = commandindex::indexer::SUPPORTED_EXTENSIONS;
+
+fn make_entry(path: &str, hash: &str) -> FileEntry {
+    FileEntry {
+        path: path.to_string(),
+        hash: hash.to_string(),
+        last_modified: chrono::Utc::now(),
+        sections: 1,
+    }
+}
+
+fn setup_dir_with_md(files: &[(&str, &str)]) -> TempDir {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    for (name, content) in files {
+        let p = dir.path().join(name);
+        if let Some(parent) = p.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&p, content).unwrap();
+    }
+    dir
+}
+
+// --- Test 1: detect_changes_detects_added_files ---
+#[test]
+fn detect_changes_detects_added_files() {
+    let dir = setup_dir_with_md(&[("new.md", "# New")]);
+    let manifest = Manifest::new(); // empty
+
+    let files = vec![dir.path().join("new.md")];
+    let result = detect_changes(dir.path(), &manifest, &files).unwrap();
+
+    assert_eq!(result.added.len(), 1);
+    assert!(result.added[0].ends_with("new.md"));
+    assert!(result.modified.is_empty());
+    assert!(result.deleted.is_empty());
+}
+
+// --- Test 2: detect_changes_detects_modified_files ---
+#[test]
+fn detect_changes_detects_modified_files() {
+    let dir = setup_dir_with_md(&[("doc.md", "# Original")]);
+    let hash = compute_file_hash(&dir.path().join("doc.md")).unwrap();
+
+    // Manifest has old hash
+    let manifest = Manifest {
+        files: vec![make_entry("doc.md", "sha256:0000old")],
+    };
+
+    let files = vec![dir.path().join("doc.md")];
+    let result = detect_changes(dir.path(), &manifest, &files).unwrap();
+
+    assert!(result.added.is_empty());
+    assert_eq!(result.modified.len(), 1);
+    assert!(result.modified[0].ends_with("doc.md"));
+    assert!(result.deleted.is_empty());
+    // Verify hash actually differs
+    assert_ne!(hash, "sha256:0000old");
+}
+
+// --- Test 3: detect_changes_detects_deleted_files ---
+#[test]
+fn detect_changes_detects_deleted_files() {
+    let dir = setup_dir_with_md(&[]); // empty dir, no files on disk
+    let manifest = Manifest {
+        files: vec![make_entry("gone.md", "sha256:abc")],
+    };
+
+    let files: Vec<std::path::PathBuf> = vec![]; // no current files
+    let result = detect_changes(dir.path(), &manifest, &files).unwrap();
+
+    assert!(result.added.is_empty());
+    assert!(result.modified.is_empty());
+    assert_eq!(result.deleted.len(), 1);
+    assert!(result.deleted[0].ends_with("gone.md"));
+}
+
+// --- Test 4: detect_changes_skips_unchanged_files ---
+#[test]
+fn detect_changes_skips_unchanged_files() {
+    let dir = setup_dir_with_md(&[("stable.md", "# Stable content")]);
+    let hash = compute_file_hash(&dir.path().join("stable.md")).unwrap();
+
+    let manifest = Manifest {
+        files: vec![make_entry("stable.md", &hash)],
+    };
+
+    let files = vec![dir.path().join("stable.md")];
+    let result = detect_changes(dir.path(), &manifest, &files).unwrap();
+
+    assert!(result.added.is_empty());
+    assert!(result.modified.is_empty());
+    assert!(result.deleted.is_empty());
+    assert_eq!(result.unchanged, 1);
+}
+
+// --- Test 5: scan_files_applies_ignore_filter ---
+#[test]
+fn scan_files_applies_ignore_filter() {
+    let dir = setup_dir_with_md(&[("included.md", "# Yes"), ("node_modules/dep.md", "# No")]);
+
+    let ignore = IgnoreFilter::default(); // ignores node_modules/**
+    let result = scan_files(dir.path(), &ignore, &["md"]).unwrap();
+
+    assert_eq!(result.files.len(), 1);
+    assert!(result.files[0].ends_with("included.md"));
+    assert_eq!(result.ignored_count, 1);
+}
+
+// --- Test 6: detect_changes_with_empty_manifest ---
+#[test]
+fn detect_changes_with_empty_manifest() {
+    let dir = setup_dir_with_md(&[("a.md", "# A"), ("b.md", "# B")]);
+    let manifest = Manifest::new();
+
+    let files = vec![dir.path().join("a.md"), dir.path().join("b.md")];
+    let result = detect_changes(dir.path(), &manifest, &files).unwrap();
+
+    assert_eq!(result.added.len(), 2);
+    assert!(result.modified.is_empty());
+    assert!(result.deleted.is_empty());
+    assert_eq!(result.unchanged, 0);
+}
+
+// --- Test 7: diff_result_is_empty ---
+#[test]
+fn diff_result_is_empty() {
+    let empty = DiffResult {
+        added: vec![],
+        modified: vec![],
+        deleted: vec![],
+        unchanged: 5,
+    };
+    assert!(empty.is_empty());
+
+    let not_empty = DiffResult {
+        added: vec![std::path::PathBuf::from("x.md")],
+        modified: vec![],
+        deleted: vec![],
+        unchanged: 0,
+    };
+    assert!(!not_empty.is_empty());
+}
+
+// --- Test 8: roundtrip_index_then_detect_changes ---
+#[test]
+fn roundtrip_index_then_detect_changes() {
+    let dir = setup_dir_with_md(&[("hello.md", "# Hello\n\nWorld\n")]);
+
+    // Run actual index command
+    common::cmd()
+        .args(["index", "--path", dir.path().to_str().unwrap()])
+        .assert()
+        .success();
+
+    // Load manifest
+    let ci_dir = dir.path().join(".commandindex");
+    let manifest = Manifest::load(&ci_dir).expect("load manifest");
+
+    // Scan files
+    let ignore = IgnoreFilter::default();
+    let scan = scan_files(dir.path(), &ignore, &["md"]).unwrap();
+
+    // Detect changes - should all be unchanged
+    let result = detect_changes(dir.path(), &manifest, &scan.files).unwrap();
+
+    assert!(result.added.is_empty());
+    assert!(result.modified.is_empty());
+    assert!(result.deleted.is_empty());
+    assert!(result.unchanged > 0);
+}
+
+// --- Test 9a: load_or_default_returns_empty_on_not_found ---
+#[test]
+fn load_or_default_returns_empty_on_not_found() {
+    let dir = tempfile::tempdir().unwrap();
+    let non_existent = dir.path().join("does_not_exist");
+    let manifest = Manifest::load_or_default(&non_existent).unwrap();
+    assert_eq!(manifest.file_count(), 0);
+}
+
+// --- Test 9b: load_or_default_propagates_other_errors ---
+#[test]
+fn load_or_default_propagates_other_errors() {
+    let dir = tempfile::tempdir().unwrap();
+    let ci_dir = dir.path().join(".commandindex");
+    fs::create_dir_all(&ci_dir).unwrap();
+    // Write invalid JSON so it triggers a Json error, not NotFound
+    fs::write(ci_dir.join("manifest.json"), "NOT VALID JSON").unwrap();
+    let result = Manifest::load_or_default(&ci_dir);
+    assert!(result.is_err());
+}
+
+// --- Test 10: scan_files_filters_by_extension ---
+#[test]
+fn scan_files_filters_by_extension() {
+    let dir = setup_dir_with_md(&[
+        ("readme.md", "# Readme"),
+        ("code.rs", "fn main() {}"),
+        ("data.txt", "hello"),
+    ]);
+
+    let ignore = IgnoreFilter::from_content(""); // no ignore rules
+    let result = scan_files(dir.path(), &ignore, &["md"]).unwrap();
+
+    assert_eq!(result.files.len(), 1);
+    assert!(result.files[0].ends_with("readme.md"));
+}
+
+// --- Test 11: detect_changes_mixed_added_modified_deleted ---
+#[test]
+fn detect_changes_mixed_added_modified_deleted() {
+    let dir = setup_dir_with_md(&[
+        ("kept.md", "# Kept same"),
+        ("changed.md", "# Changed content"),
+        ("brand_new.md", "# Brand new"),
+    ]);
+
+    let kept_hash = compute_file_hash(&dir.path().join("kept.md")).unwrap();
+
+    let manifest = Manifest {
+        files: vec![
+            make_entry("kept.md", &kept_hash),           // unchanged
+            make_entry("changed.md", "sha256:oldhash"),  // modified
+            make_entry("removed.md", "sha256:whatever"), // deleted
+        ],
+    };
+
+    let files = vec![
+        dir.path().join("kept.md"),
+        dir.path().join("changed.md"),
+        dir.path().join("brand_new.md"),
+    ];
+
+    let result = detect_changes(dir.path(), &manifest, &files).unwrap();
+
+    assert_eq!(result.added.len(), 1, "added");
+    assert_eq!(result.modified.len(), 1, "modified");
+    assert_eq!(result.deleted.len(), 1, "deleted");
+    assert_eq!(result.unchanged, 1, "unchanged");
+
+    assert!(result.added[0].ends_with("brand_new.md"));
+    assert!(result.modified[0].ends_with("changed.md"));
+    assert!(result.deleted[0].ends_with("removed.md"));
+}
+
+// --- Bonus: to_relative_path_string ---
+#[test]
+fn to_relative_path_string_works() {
+    let base = Path::new("/home/user/project");
+    let abs = Path::new("/home/user/project/docs/readme.md");
+    assert_eq!(to_relative_path_string(abs, base), "docs/readme.md");
+
+    // When not a prefix, returns the absolute path as-is
+    let other = Path::new("/other/path/file.md");
+    assert_eq!(to_relative_path_string(other, base), "/other/path/file.md");
+}


### PR DESCRIPTION
## Summary
- manifest.json比較による変更/追加/削除ファイル検出エンジン
- DiffResult構造体、detect_changes関数
- .cmindexignore対応、拡張子フィルタ
- Manifest::load_or_default追加
- 13テスト追加（141テスト全パス）

## Test plan
- [x] `cargo test --all` 全パス
- [x] `cargo clippy --all-targets -- -D warnings` 警告0件

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)