### PR TITLE
feat: tantivy インデックス差分更新実装

### DIFF
--- a/src/cli/index.rs
+++ b/src/cli/index.rs
@@ -5,7 +5,9 @@ use std::time::{Duration, Instant};
 use chrono::{DateTime, Utc};
 use walkdir::WalkDir;
 
-use crate::indexer::manifest::{self, FileEntry, Manifest, ManifestError};
+use crate::indexer::SUPPORTED_EXTENSIONS;
+use crate::indexer::diff::{DiffError, detect_changes, scan_files};
+use crate::indexer::manifest::{self, FileEntry, Manifest, ManifestError, to_relative_path_string};
 use crate::indexer::state::{IndexState, StateError};
 use crate::indexer::writer::{IndexWriterWrapper, SectionDoc, WriterError};
 use crate::parser::ignore::{IgnoreError, IgnoreFilter};
@@ -19,6 +21,7 @@ pub enum IndexError {
     State(StateError),
     Manifest(ManifestError),
     Ignore(IgnoreError),
+    Diff(DiffError),
 }
 
 impl fmt::Display for IndexError {
@@ -30,6 +33,7 @@ impl fmt::Display for IndexError {
             IndexError::State(e) => write!(f, "State error: {e}"),
             IndexError::Manifest(e) => write!(f, "Manifest error: {e}"),
             IndexError::Ignore(e) => write!(f, "Ignore filter error: {e}"),
+            IndexError::Diff(e) => write!(f, "Diff error: {e}"),
         }
     }
 }
@@ -43,6 +47,7 @@ impl std::error::Error for IndexError {
             IndexError::State(e) => Some(e),
             IndexError::Manifest(e) => Some(e),
             IndexError::Ignore(e) => Some(e),
+            IndexError::Diff(e) => Some(e),
         }
     }
 }
@@ -80,6 +85,12 @@ impl From<ManifestError> for IndexError {
 impl From<IgnoreError> for IndexError {
     fn from(e: IgnoreError) -> Self {
         IndexError::Ignore(e)
+    }
+}
+
+impl From<DiffError> for IndexError {
+    fn from(e: DiffError) -> Self {
+        IndexError::Diff(e)
     }
 }
 
@@ -218,6 +229,227 @@ pub fn run(path: &Path) -> Result<IndexSummary, IndexError> {
         indexed_sections,
         skipped,
         ignored,
+        duration: start.elapsed(),
+    })
+}
+
+pub struct IncrementalSummary {
+    pub added_files: u64,
+    pub added_sections: u64,
+    pub modified_files: u64,
+    pub modified_sections: u64,
+    pub deleted_files: u64,
+    pub unchanged: u64,
+    pub skipped: u64,
+    pub duration: Duration,
+}
+
+/// Result type for parse failures that should be skipped vs fatal errors.
+enum IndexFileResult {
+    Skipped,
+    Error(IndexError),
+}
+
+/// Parse a file, add its sections to the index, and upsert the manifest entry.
+/// Returns the number of sections indexed, or `IndexFileResult::Skipped` on parse failure.
+fn index_file_and_upsert(
+    file_path: &Path,
+    rel_path: &str,
+    writer: &mut IndexWriterWrapper,
+    manifest: &mut Manifest,
+) -> Result<u64, IndexFileResult> {
+    let doc = match markdown::parse_file(file_path) {
+        Ok(doc) => doc,
+        Err(e) => {
+            eprintln!("Warning: skipping {}: {e}", file_path.display());
+            return Err(IndexFileResult::Skipped);
+        }
+    };
+
+    let section_count = doc.sections.len() as u64;
+    for section in &doc.sections {
+        let section_doc = section_to_doc(section, rel_path, doc.frontmatter.as_ref());
+        writer
+            .add_section(&section_doc)
+            .map_err(|e| IndexFileResult::Error(e.into()))?;
+    }
+
+    let hash =
+        manifest::compute_file_hash(file_path).unwrap_or_else(|_| "sha256:unknown".to_string());
+    let last_modified = std::fs::metadata(file_path)
+        .and_then(|m| m.modified())
+        .map(DateTime::<Utc>::from)
+        .unwrap_or_else(|_| Utc::now());
+
+    manifest.upsert_entry(FileEntry {
+        path: rel_path.to_string(),
+        hash,
+        last_modified,
+        sections: section_count,
+    });
+
+    Ok(section_count)
+}
+
+fn fallback_to_full_index(path: &Path) -> Result<IncrementalSummary, IndexError> {
+    eprintln!("Note: No existing index found. Running full index...");
+    let summary = run(path)?;
+    Ok(IncrementalSummary {
+        added_files: summary.scanned,
+        added_sections: summary.indexed_sections,
+        modified_files: 0,
+        modified_sections: 0,
+        deleted_files: 0,
+        unchanged: 0,
+        skipped: summary.skipped,
+        duration: summary.duration,
+    })
+}
+
+pub fn run_incremental(path: &Path) -> Result<IncrementalSummary, IndexError> {
+    let start = Instant::now();
+
+    // 1. Validate target directory
+    if !path.is_dir() {
+        return Err(IndexError::Io(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("Directory not found: {}", path.display()),
+        )));
+    }
+
+    // 2. Check preconditions: existing index with valid schema
+    let commandindex_dir = crate::indexer::commandindex_dir(path);
+    if !IndexState::exists(&commandindex_dir) {
+        return fallback_to_full_index(path);
+    }
+    let mut state = match IndexState::load(&commandindex_dir) {
+        Ok(s) => s,
+        Err(_) => return fallback_to_full_index(path),
+    };
+    if state.check_schema_version().is_err() {
+        return fallback_to_full_index(path);
+    }
+
+    // 3. Load ignore filter (from_file returns default if file not found)
+    let ignore_filter = IgnoreFilter::from_file(&path.join(".cmindexignore"))?;
+
+    // 4. Scan files
+    let scan_result = scan_files(path, &ignore_filter, SUPPORTED_EXTENSIONS)?;
+
+    // 5. Load old manifest
+    let mut old_manifest = Manifest::load_or_default(&commandindex_dir)?;
+
+    // 6. Detect changes
+    let diff_result = detect_changes(path, &old_manifest, &scan_result.files)?;
+
+    // 7. Early return if no changes
+    if diff_result.is_empty() {
+        return Ok(IncrementalSummary {
+            added_files: 0,
+            added_sections: 0,
+            modified_files: 0,
+            modified_sections: 0,
+            deleted_files: 0,
+            unchanged: diff_result.unchanged as u64,
+            skipped: 0,
+            duration: start.elapsed(),
+        });
+    }
+
+    // 8. Open existing tantivy index
+    let tantivy_dir = crate::indexer::index_dir(path);
+    let mut writer = match IndexWriterWrapper::open_existing(&tantivy_dir) {
+        Ok(w) => w,
+        Err(_) => return fallback_to_full_index(path),
+    };
+
+    let mut added_files: u64 = 0;
+    let mut added_sections: u64 = 0;
+    let mut modified_files: u64 = 0;
+    let mut modified_sections: u64 = 0;
+    let mut deleted_files: u64 = 0;
+    let mut skipped: u64 = 0;
+
+    // Track old sections for state update
+    let mut old_deleted_sections: u64 = 0;
+    let mut old_modified_sections: u64 = 0;
+
+    // 9. Process deleted files
+    for del_path in &diff_result.deleted {
+        let path_str = del_path.to_string_lossy().to_string();
+        writer.delete_by_path(&path_str)?;
+
+        // Track old sections count
+        if let Some(entry) = old_manifest.find_by_path(&path_str) {
+            old_deleted_sections += entry.sections;
+        }
+
+        old_manifest.remove_by_path(&path_str);
+        deleted_files += 1;
+    }
+
+    // 10. Process modified files
+    for mod_path in &diff_result.modified {
+        let rel_path = to_relative_path_string(mod_path, path);
+
+        // Track old sections count
+        if let Some(entry) = old_manifest.find_by_path(&rel_path) {
+            old_modified_sections += entry.sections;
+        }
+
+        writer.delete_by_path(&rel_path)?;
+
+        match index_file_and_upsert(mod_path, &rel_path, &mut writer, &mut old_manifest) {
+            Ok(section_count) => {
+                modified_files += 1;
+                modified_sections += section_count;
+            }
+            Err(IndexFileResult::Skipped) => {
+                skipped += 1;
+            }
+            Err(IndexFileResult::Error(e)) => return Err(e),
+        }
+    }
+
+    // 11. Process added files
+    for add_path in &diff_result.added {
+        let rel_path = to_relative_path_string(add_path, path);
+
+        match index_file_and_upsert(add_path, &rel_path, &mut writer, &mut old_manifest) {
+            Ok(section_count) => {
+                added_files += 1;
+                added_sections += section_count;
+            }
+            Err(IndexFileResult::Skipped) => {
+                skipped += 1;
+            }
+            Err(IndexFileResult::Error(e)) => return Err(e),
+        }
+    }
+
+    // 12. Commit index
+    writer.commit()?;
+
+    // 13. Save updated manifest
+    old_manifest.save(&commandindex_dir)?;
+
+    // 14. Update state
+    state.total_files += added_files;
+    state.total_files -= deleted_files;
+    state.total_sections += added_sections + modified_sections;
+    state.total_sections -= old_deleted_sections + old_modified_sections;
+    state.touch();
+    state.save(&commandindex_dir)?;
+
+    // 15. Return summary
+    Ok(IncrementalSummary {
+        added_files,
+        added_sections,
+        modified_files,
+        modified_sections,
+        deleted_files,
+        unchanged: diff_result.unchanged as u64,
+        skipped,
         duration: start.elapsed(),
     })
 }

--- a/src/indexer/manifest.rs
+++ b/src/indexer/manifest.rs
@@ -99,6 +99,20 @@ impl Manifest {
         self.files.iter().find(|e| e.path == path)
     }
 
+    /// 指定パスのエントリを削除
+    pub fn remove_by_path(&mut self, path: &str) {
+        self.files.retain(|e| e.path != path);
+    }
+
+    /// エントリを追加または更新（既存パスがあれば上書き）
+    pub fn upsert_entry(&mut self, entry: FileEntry) {
+        if let Some(existing) = self.files.iter_mut().find(|e| e.path == entry.path) {
+            *existing = entry;
+        } else {
+            self.files.push(entry);
+        }
+    }
+
     /// manifest.json を読み込む。ファイルが存在しない場合は空の Manifest を返す。
     pub fn load_or_default(commandindex_dir: &Path) -> Result<Self, ManifestError> {
         match Self::load(commandindex_dir) {

--- a/src/indexer/writer.rs
+++ b/src/indexer/writer.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 use std::path::Path;
-use tantivy::{Index, IndexWriter as TantivyIndexWriter, doc};
+use tantivy::{Index, IndexWriter as TantivyIndexWriter, Term, doc};
 
 use crate::indexer::schema::IndexSchema;
 
@@ -95,6 +95,14 @@ impl IndexWriterWrapper {
             self.schema.heading_level => section.heading_level,
             self.schema.line_start => section.line_start,
         ))?;
+        Ok(())
+    }
+
+    /// path フィールド（STRING 型）をキーに、該当パスの全ドキュメントを削除する。
+    /// 1ファイルに複数セクションがある場合も全て削除される。
+    pub fn delete_by_path(&mut self, path: &str) -> Result<(), WriterError> {
+        let term = Term::from_field_text(self.schema.path, path);
+        self.writer.delete_term(term);
         Ok(())
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,11 @@ enum Commands {
         limit: usize,
     },
     /// Incrementally update the index
-    Update,
+    Update {
+        /// Target directory
+        #[arg(long, default_value = ".")]
+        path: PathBuf,
+    },
     /// Show index status
     Status {
         /// Target directory
@@ -109,10 +113,28 @@ fn main() {
                 }
             }
         }
-        Commands::Update => {
-            eprintln!("Error: `update` command is not yet implemented. Coming in Phase 2.");
-            1
-        }
+        Commands::Update { path } => match commandindex::cli::index::run_incremental(&path) {
+            Ok(summary) => {
+                println!("Incremental update completed:");
+                println!(
+                    "  Added:     {} files ({} sections)",
+                    summary.added_files, summary.added_sections
+                );
+                println!(
+                    "  Modified:  {} files ({} sections)",
+                    summary.modified_files, summary.modified_sections
+                );
+                println!("  Deleted:   {} files", summary.deleted_files);
+                println!("  Unchanged: {} files", summary.unchanged);
+                println!("  Skipped:   {} files", summary.skipped);
+                println!("  Duration:  {:.2}s", summary.duration.as_secs_f64());
+                0
+            }
+            Err(e) => {
+                eprintln!("Error: {e}");
+                1
+            }
+        },
         Commands::Status { path, format } => {
             match commandindex::cli::status::run(&path, format, &mut std::io::stdout()) {
                 Ok(()) => 0,

--- a/tests/cli_args.rs
+++ b/tests/cli_args.rs
@@ -82,12 +82,15 @@ fn search_with_all_options_accepted() {
 }
 
 #[test]
-fn update_subcommand_exits_with_not_implemented() {
+fn update_subcommand_runs_successfully() {
+    // update without existing index triggers fallback to full index
+    let dir = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(dir.path().join("test.md"), "# Test\n\nContent\n").unwrap();
     common::cmd()
-        .arg("update")
+        .args(["update", "--path", dir.path().to_str().unwrap()])
         .assert()
-        .failure()
-        .stderr(predicate::str::contains("not yet implemented"));
+        .success()
+        .stdout(predicate::str::contains("Incremental update completed"));
 }
 
 #[test]

--- a/tests/incremental_update.rs
+++ b/tests/incremental_update.rs
@@ -1,0 +1,197 @@
+mod common;
+
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+
+fn setup_single_file() -> TempDir {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    fs::write(
+        dir.path().join("doc.md"),
+        "# Original Title\n\nOriginal content\n",
+    )
+    .unwrap();
+    dir
+}
+
+fn run_index(dir: &TempDir) {
+    common::cmd()
+        .args(["index", "--path", dir.path().to_str().unwrap()])
+        .assert()
+        .success();
+}
+
+fn run_update(dir: &TempDir) -> assert_cmd::assert::Assert {
+    common::cmd()
+        .args(["update", "--path", dir.path().to_str().unwrap()])
+        .assert()
+}
+
+#[test]
+fn update_adds_new_files() {
+    let dir = setup_single_file();
+    run_index(&dir);
+
+    // Add a new file
+    fs::write(
+        dir.path().join("new.md"),
+        "# New File\n\nNew content about Rust programming\n",
+    )
+    .unwrap();
+
+    run_update(&dir)
+        .success()
+        .stdout(predicate::str::contains("Added:").and(predicate::str::contains("1 files")));
+
+    // Verify new content is searchable
+    common::cmd()
+        .args(["search", "Rust programming", "--format", "json"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("New File"));
+}
+
+#[test]
+fn update_modifies_existing_files() {
+    let dir = setup_single_file();
+    run_index(&dir);
+
+    // Modify the file
+    fs::write(
+        dir.path().join("doc.md"),
+        "# Updated Title\n\nUpdated content about Kubernetes\n",
+    )
+    .unwrap();
+
+    run_update(&dir)
+        .success()
+        .stdout(predicate::str::contains("Modified:").and(predicate::str::contains("1 files")));
+
+    // Verify updated content is searchable
+    common::cmd()
+        .args(["search", "Kubernetes", "--format", "json"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Updated Title"));
+
+    // Verify old content is NOT searchable
+    common::cmd()
+        .args(["search", "Original content", "--format", "json"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Original Title").not());
+}
+
+#[test]
+fn update_removes_deleted_files() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    fs::write(dir.path().join("keep.md"), "# Keep\n\nThis stays\n").unwrap();
+    fs::write(
+        dir.path().join("remove.md"),
+        "# Remove\n\nThis will be removed\n",
+    )
+    .unwrap();
+    run_index(&dir);
+
+    // Delete one file
+    fs::remove_file(dir.path().join("remove.md")).unwrap();
+
+    run_update(&dir)
+        .success()
+        .stdout(predicate::str::contains("Deleted:").and(predicate::str::contains("1 files")));
+
+    // Verify deleted content is NOT searchable
+    common::cmd()
+        .args(["search", "removed", "--format", "json"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Remove").not());
+}
+
+#[test]
+fn update_skips_unchanged_files() {
+    let dir = setup_single_file();
+    run_index(&dir);
+
+    // No changes, run update
+    run_update(&dir)
+        .success()
+        .stdout(predicate::str::contains("Unchanged: 1"));
+}
+
+#[test]
+fn update_fallback_to_full_index() {
+    let dir = setup_single_file();
+    // Do NOT run index first - no existing index
+
+    run_update(&dir)
+        .success()
+        .stderr(predicate::str::contains("full index"));
+}
+
+#[test]
+fn update_manifest_updated() {
+    let dir = setup_single_file();
+    run_index(&dir);
+
+    // Add a new file
+    fs::write(dir.path().join("extra.md"), "# Extra\n\nExtra content\n").unwrap();
+
+    run_update(&dir).success();
+
+    // Check manifest
+    let manifest_path = dir.path().join(".commandindex/manifest.json");
+    let content = fs::read_to_string(&manifest_path).unwrap();
+    let manifest: serde_json::Value = serde_json::from_str(&content).unwrap();
+
+    let files = manifest["files"].as_array().unwrap();
+    assert_eq!(
+        files.len(),
+        2,
+        "manifest should have 2 files after adding one"
+    );
+
+    // Check that extra.md is in the manifest
+    let has_extra = files.iter().any(|f| f["path"].as_str() == Some("extra.md"));
+    assert!(has_extra, "manifest should contain extra.md");
+}
+
+#[test]
+fn update_state_updated() {
+    let dir = setup_single_file();
+    run_index(&dir);
+
+    // Read initial state
+    let state_path = dir.path().join(".commandindex/state.json");
+    let initial_state: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&state_path).unwrap()).unwrap();
+    let initial_updated = initial_state["last_updated_at"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Add a new file
+    fs::write(dir.path().join("extra.md"), "# Extra\n\nExtra content\n").unwrap();
+
+    // Small delay to ensure timestamp differs
+    std::thread::sleep(std::time::Duration::from_millis(100));
+
+    run_update(&dir).success();
+
+    // Check state
+    let updated_state: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&state_path).unwrap()).unwrap();
+
+    assert_eq!(updated_state["total_files"], 2);
+    assert_eq!(updated_state["total_sections"], 2);
+
+    let updated_at = updated_state["last_updated_at"].as_str().unwrap();
+    assert_ne!(
+        updated_at, initial_updated,
+        "last_updated_at should change after update"
+    );
+}

--- a/tests/indexer_state.rs
+++ b/tests/indexer_state.rs
@@ -197,3 +197,74 @@ fn test_compute_file_hash_nonexistent() {
     let path = tmp.path().join("nonexistent.md");
     assert!(manifest::compute_file_hash(&path).is_err());
 }
+
+// === Manifest remove_by_path / upsert_entry tests ===
+
+#[test]
+fn manifest_remove_by_path_removes_entry() {
+    let mut manifest = Manifest::new();
+    manifest.add_entry(FileEntry {
+        path: "docs/target.md".to_string(),
+        hash: "sha256:aaa".to_string(),
+        last_modified: Utc::now(),
+        sections: 2,
+    });
+    assert_eq!(manifest.file_count(), 1);
+
+    manifest.remove_by_path("docs/target.md");
+    assert!(manifest.find_by_path("docs/target.md").is_none());
+    assert_eq!(manifest.file_count(), 0);
+}
+
+#[test]
+fn manifest_remove_by_path_nonexistent_is_noop() {
+    let mut manifest = Manifest::new();
+    manifest.add_entry(FileEntry {
+        path: "docs/keep.md".to_string(),
+        hash: "sha256:bbb".to_string(),
+        last_modified: Utc::now(),
+        sections: 1,
+    });
+    let count_before = manifest.file_count();
+
+    manifest.remove_by_path("docs/nonexistent.md");
+    assert_eq!(manifest.file_count(), count_before);
+}
+
+#[test]
+fn manifest_upsert_entry_adds_new() {
+    let mut manifest = Manifest::new();
+    assert_eq!(manifest.file_count(), 0);
+
+    manifest.upsert_entry(FileEntry {
+        path: "docs/new.md".to_string(),
+        hash: "sha256:ccc".to_string(),
+        last_modified: Utc::now(),
+        sections: 3,
+    });
+    assert_eq!(manifest.file_count(), 1);
+    assert!(manifest.find_by_path("docs/new.md").is_some());
+}
+
+#[test]
+fn manifest_upsert_entry_updates_existing() {
+    let mut manifest = Manifest::new();
+    manifest.add_entry(FileEntry {
+        path: "docs/existing.md".to_string(),
+        hash: "sha256:old".to_string(),
+        last_modified: Utc::now(),
+        sections: 1,
+    });
+
+    manifest.upsert_entry(FileEntry {
+        path: "docs/existing.md".to_string(),
+        hash: "sha256:new".to_string(),
+        last_modified: Utc::now(),
+        sections: 5,
+    });
+
+    assert_eq!(manifest.file_count(), 1);
+    let entry = manifest.find_by_path("docs/existing.md").unwrap();
+    assert_eq!(entry.hash, "sha256:new");
+    assert_eq!(entry.sections, 5);
+}

--- a/tests/indexer_tantivy.rs
+++ b/tests/indexer_tantivy.rs
@@ -410,3 +410,136 @@ fn test_search_with_options_delegates_from_search() {
     let results = reader.search("authentication", 10).unwrap();
     assert!(!results.is_empty());
 }
+
+// === delete_by_path tests ===
+
+#[test]
+fn delete_by_path_removes_single_section() {
+    let tmp = TempDir::new().unwrap();
+    let index_dir = tmp.path().join("tantivy");
+
+    // Add a section
+    {
+        let mut writer = IndexWriterWrapper::open(&index_dir).unwrap();
+        writer
+            .add_section(&create_test_section(
+                "docs/target.md",
+                "Target",
+                "This is the target document to be deleted.",
+                "test",
+            ))
+            .unwrap();
+        writer.commit().unwrap();
+    }
+
+    // Verify it exists
+    {
+        let reader = IndexReaderWrapper::open(&index_dir).unwrap();
+        let results = reader.search("target", 10).unwrap();
+        assert_eq!(results.len(), 1);
+    }
+
+    // Delete by path
+    {
+        let mut writer = IndexWriterWrapper::open_existing(&index_dir).unwrap();
+        writer.delete_by_path("docs/target.md").unwrap();
+        writer.commit().unwrap();
+    }
+
+    // Verify it's gone
+    {
+        let reader = IndexReaderWrapper::open(&index_dir).unwrap();
+        let results = reader.search("target", 10).unwrap();
+        assert_eq!(results.len(), 0);
+    }
+}
+
+#[test]
+fn delete_by_path_removes_multiple_sections() {
+    let tmp = TempDir::new().unwrap();
+    let index_dir = tmp.path().join("tantivy");
+
+    // Add 3 sections with the same path
+    {
+        let mut writer = IndexWriterWrapper::open(&index_dir).unwrap();
+        for i in 0..3 {
+            writer
+                .add_section(&create_test_section(
+                    "docs/multi.md",
+                    &format!("Section {i}"),
+                    &format!("Body content for section {i} of multi document."),
+                    "multi",
+                ))
+                .unwrap();
+        }
+        writer.commit().unwrap();
+    }
+
+    // Verify all 3 exist
+    {
+        let reader = IndexReaderWrapper::open(&index_dir).unwrap();
+        let results = reader.search("multi", 10).unwrap();
+        assert_eq!(results.len(), 3);
+    }
+
+    // Delete by path
+    {
+        let mut writer = IndexWriterWrapper::open_existing(&index_dir).unwrap();
+        writer.delete_by_path("docs/multi.md").unwrap();
+        writer.commit().unwrap();
+    }
+
+    // Verify all are gone
+    {
+        let reader = IndexReaderWrapper::open(&index_dir).unwrap();
+        let results = reader.search("multi", 10).unwrap();
+        assert_eq!(results.len(), 0);
+    }
+}
+
+#[test]
+fn delete_by_path_does_not_affect_other_paths() {
+    let tmp = TempDir::new().unwrap();
+    let index_dir = tmp.path().join("tantivy");
+
+    // Add two sections with different paths
+    {
+        let mut writer = IndexWriterWrapper::open(&index_dir).unwrap();
+        writer
+            .add_section(&create_test_section(
+                "docs/keep.md",
+                "Keep This",
+                "This document should be kept after deletion of other.",
+                "keep",
+            ))
+            .unwrap();
+        writer
+            .add_section(&create_test_section(
+                "docs/remove.md",
+                "Remove This",
+                "This document should be removed.",
+                "remove",
+            ))
+            .unwrap();
+        writer.commit().unwrap();
+    }
+
+    // Delete only remove.md
+    {
+        let mut writer = IndexWriterWrapper::open_existing(&index_dir).unwrap();
+        writer.delete_by_path("docs/remove.md").unwrap();
+        writer.commit().unwrap();
+    }
+
+    // Verify keep.md still exists
+    {
+        let reader = IndexReaderWrapper::open(&index_dir).unwrap();
+        let results = reader.search("kept", 10).unwrap();
+        assert!(!results.is_empty());
+        assert_eq!(results[0].path, "docs/keep.md");
+
+        // Verify remove.md is gone
+        let results2 = reader.search("removed", 10).unwrap();
+        assert!(results2.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary
- incremental_update関数（差分検知→tantivy更新→manifest更新の一括処理）
- delete_by_path（tantivy term削除）
- Manifest操作メソッド追加（remove_by_path, replace_entry）
- UpdateSummary構造体
- updateコマンドのCLI統合
- 統合テスト追加（170テスト全パス）

## Test plan
- [x] `cargo test --all` 全パス (170テスト)
- [x] `cargo clippy --all-targets -- -D warnings` 警告0件

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)