### PR TITLE
feat: updateコマンド実装

### DIFF
--- a/src/cli/index.rs
+++ b/src/cli/index.rs
@@ -433,11 +433,24 @@ pub fn run_incremental(path: &Path) -> Result<IncrementalSummary, IndexError> {
     // 13. Save updated manifest
     old_manifest.save(&commandindex_dir)?;
 
-    // 14. Update state
-    state.total_files += added_files;
-    state.total_files -= deleted_files;
-    state.total_sections += added_sections + modified_sections;
-    state.total_sections -= old_deleted_sections + old_modified_sections;
+    // 14. Update state (use saturating arithmetic to prevent underflow on corrupted state)
+    state.total_files = state.total_files.saturating_add(added_files);
+    if deleted_files > state.total_files {
+        eprintln!(
+            "Warning: state inconsistency detected (total_files underflow). Consider running `commandindex clean` and `commandindex index`."
+        );
+    }
+    state.total_files = state.total_files.saturating_sub(deleted_files);
+    state.total_sections = state
+        .total_sections
+        .saturating_add(added_sections + modified_sections);
+    let sections_to_remove = old_deleted_sections + old_modified_sections;
+    if sections_to_remove > state.total_sections {
+        eprintln!(
+            "Warning: state inconsistency detected (total_sections underflow). Consider running `commandindex clean` and `commandindex index`."
+        );
+    }
+    state.total_sections = state.total_sections.saturating_sub(sections_to_remove);
     state.touch();
     state.save(&commandindex_dir)?;
 

--- a/src/indexer/diff.rs
+++ b/src/indexer/diff.rs
@@ -72,6 +72,7 @@ pub fn scan_files(
     let mut ignored_count: u64 = 0;
 
     for entry in WalkDir::new(base_path)
+        .follow_links(false)
         .into_iter()
         .filter_map(|e| e.ok())
         .filter(|e| e.file_type().is_file())

--- a/tests/incremental_update.rs
+++ b/tests/incremental_update.rs
@@ -161,6 +161,44 @@ fn update_manifest_updated() {
 }
 
 #[test]
+fn update_state_no_underflow() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    fs::write(dir.path().join("keep.md"), "# Keep\n\nKeep content\n").unwrap();
+    fs::write(dir.path().join("remove.md"), "# Remove\n\nRemove content\n").unwrap();
+    run_index(&dir);
+
+    // Corrupt state.json: set total_files and total_sections to 0
+    let state_path = dir.path().join(".commandindex/state.json");
+    let state_content = fs::read_to_string(&state_path).unwrap();
+    let mut state: serde_json::Value = serde_json::from_str(&state_content).unwrap();
+    state["total_files"] = serde_json::Value::from(0u64);
+    state["total_sections"] = serde_json::Value::from(0u64);
+    fs::write(&state_path, serde_json::to_string_pretty(&state).unwrap()).unwrap();
+
+    // Delete one file — this would cause underflow without saturating_sub
+    fs::remove_file(dir.path().join("remove.md")).unwrap();
+
+    // Should not panic, should succeed
+    run_update(&dir).success();
+
+    // Verify state values are >= 0 (u64 so always true, but not wrapped to huge values)
+    let final_state: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&state_path).unwrap()).unwrap();
+    let total_files = final_state["total_files"].as_u64().unwrap();
+    let total_sections = final_state["total_sections"].as_u64().unwrap();
+
+    // With saturating_sub, values should be 0 (not wrapped to u64::MAX - N)
+    assert!(
+        total_files <= 10,
+        "total_files should not be a huge wrapped value, got {total_files}"
+    );
+    assert!(
+        total_sections <= 10,
+        "total_sections should not be a huge wrapped value, got {total_sections}"
+    );
+}
+
+#[test]
 fn update_state_updated() {
     let dir = setup_single_file();
     run_index(&dir);


### PR DESCRIPTION
## Summary
- updateコマンドの品質改善（saturating_sub、follow_links、出力メッセージ統一）
- E2Eテスト拡充（8テスト）
- 全受け入れ基準9件クリア

## Test plan
- [x] `cargo test --all` 全パス
- [x] `cargo clippy --all-targets -- -D warnings` 警告0件

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)