### PR TITLE
feat: tree-sitter ソースコードパーサー基盤（TypeScript, Python）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,9 @@ src/
 ├── lib.rs               # モジュール宣言
 ├── cli/                 # CLI サブコマンド（index, clean）
 ├── parser/              # Markdown / ソースコード解析
+│   ├── code.rs          # コード解析共通型（SymbolInfo, CodeParseResult 等）
+│   ├── typescript.rs    # TypeScript/TSX パーサー（tree-sitter）
+│   └── python.rs        # Python パーサー（tree-sitter）
 ├── indexer/             # tantivy / SQLite インデックス操作
 ├── search/              # 検索ロジック
 └── output/              # 出力フォーマット（human / json / path）

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,6 +416,9 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "tree-sitter",
+ "tree-sitter-python",
+ "tree-sitter-typescript",
  "walkdir",
 ]
 
@@ -2432,6 +2435,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -2539,6 +2543,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "strsim"
@@ -3023,6 +3033,46 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.26.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a6592b1aec0109df37b6bafea77eb4e61466e37b0a5a98bef4f89bfb81b7a2"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax",
+ "serde_json",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-python"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bf85fd39652e740bf60f46f4cda9492c3a9ad75880575bf14960f775cb74a1c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-typescript"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ lindera-tantivy = { version = "2.0", features = ["embed-ipadic"] }
 sha2 = "0.10"
 chrono = { version = "0.4", features = ["serde"] }
 colored = "2"
+tree-sitter = "0.26"
+tree-sitter-typescript = "0.23"
+tree-sitter-python = "0.25"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/parser/code.rs
+++ b/src/parser/code.rs
@@ -1,0 +1,136 @@
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+const MAX_FILE_SIZE: u64 = 10 * 1024 * 1024; // 10MB
+
+/// Maximum AST traversal depth to prevent stack overflow on deeply nested code.
+pub const MAX_DEPTH: usize = 256;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum SymbolKind {
+    Function,
+    Class,
+    Method,
+}
+
+impl fmt::Display for SymbolKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SymbolKind::Function => write!(f, "Function"),
+            SymbolKind::Class => write!(f, "Class"),
+            SymbolKind::Method => write!(f, "Method"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SymbolInfo {
+    pub name: String,
+    pub kind: SymbolKind,
+    pub file_path: PathBuf,
+    pub line_start: usize,
+    pub line_end: usize,
+    pub parent: Option<String>,
+    pub is_exported: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ImportInfo {
+    pub source: String,
+    pub imported_names: Vec<String>,
+    pub file_path: PathBuf,
+}
+
+#[derive(Debug)]
+pub struct CodeParseResult {
+    pub file_path: PathBuf,
+    pub symbols: Vec<SymbolInfo>,
+    pub imports: Vec<ImportInfo>,
+}
+
+#[derive(Debug)]
+pub enum CodeParseError {
+    Io(std::io::Error),
+    TreeSitter(String),
+    UnsupportedLanguage(String),
+    FileTooLarge { path: PathBuf, size: u64 },
+}
+
+impl fmt::Display for CodeParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CodeParseError::Io(e) => write!(f, "IO error: {e}"),
+            CodeParseError::TreeSitter(msg) => write!(f, "Tree-sitter error: {msg}"),
+            CodeParseError::UnsupportedLanguage(lang) => {
+                write!(f, "Unsupported language: {lang}")
+            }
+            CodeParseError::FileTooLarge { path, size } => {
+                write!(
+                    f,
+                    "File too large: {} ({size} bytes, max {MAX_FILE_SIZE})",
+                    path.display()
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for CodeParseError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            CodeParseError::Io(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<std::io::Error> for CodeParseError {
+    fn from(e: std::io::Error) -> Self {
+        CodeParseError::Io(e)
+    }
+}
+
+/// Parse content with tree-sitter using the given language.
+pub fn parse_with_tree_sitter(
+    content: &str,
+    language: &tree_sitter::Language,
+) -> Result<tree_sitter::Tree, CodeParseError> {
+    let mut parser = tree_sitter::Parser::new();
+    parser
+        .set_language(language)
+        .map_err(|e| CodeParseError::TreeSitter(format!("Failed to set language: {e}")))?;
+    parser
+        .parse(content, None)
+        .ok_or_else(|| CodeParseError::TreeSitter("Failed to parse content".to_string()))
+}
+
+/// Dispatch to the appropriate parser based on file extension (with file size check).
+pub fn parse_code_file(path: &Path) -> Result<CodeParseResult, CodeParseError> {
+    // Check file size
+    let metadata = std::fs::metadata(path)?;
+    let size = metadata.len();
+    if size > MAX_FILE_SIZE {
+        return Err(CodeParseError::FileTooLarge {
+            path: path.to_path_buf(),
+            size,
+        });
+    }
+
+    let content = std::fs::read_to_string(path)?;
+
+    let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+
+    match ext {
+        "ts" => super::typescript::parse_typescript_content(&content, path),
+        "tsx" => super::typescript::parse_tsx_content(&content, path),
+        "py" => super::python::parse_python_content(&content, path),
+        other => Err(CodeParseError::UnsupportedLanguage(other.to_string())),
+    }
+}
+
+/// Extract the text of a named child field from a tree-sitter node.
+pub fn get_child_text(node: &tree_sitter::Node, field_name: &str, src: &[u8]) -> Option<String> {
+    node.child_by_field_name(field_name)
+        .and_then(|n| n.utf8_text(src).ok())
+        .map(|s| s.to_string())
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,7 +1,10 @@
+pub mod code;
 pub mod frontmatter;
 pub mod ignore;
 pub mod link;
 pub mod markdown;
+pub mod python;
+pub mod typescript;
 
 pub use frontmatter::Frontmatter;
 pub use link::{Link, LinkType};

--- a/src/parser/python.rs
+++ b/src/parser/python.rs
@@ -1,0 +1,165 @@
+use std::path::Path;
+
+use crate::parser::code::{
+    CodeParseError, CodeParseResult, ImportInfo, MAX_DEPTH, SymbolInfo, SymbolKind, get_child_text,
+    parse_with_tree_sitter,
+};
+
+/// Parse Python source code and extract symbols and imports.
+pub fn parse_python_content(
+    source: &str,
+    file_path: &Path,
+) -> Result<CodeParseResult, CodeParseError> {
+    let language: tree_sitter::Language = tree_sitter_python::LANGUAGE.into();
+    let tree = parse_with_tree_sitter(source, &language)?;
+    let root = tree.root_node();
+
+    let mut ctx = PyWalkContext {
+        src: source.as_bytes(),
+        file_path,
+        symbols: Vec::new(),
+        imports: Vec::new(),
+    };
+
+    walk_py_node(&mut ctx, root, None, 0);
+
+    Ok(CodeParseResult {
+        file_path: file_path.to_path_buf(),
+        symbols: ctx.symbols,
+        imports: ctx.imports,
+    })
+}
+
+struct PyWalkContext<'a> {
+    src: &'a [u8],
+    file_path: &'a Path,
+    symbols: Vec<SymbolInfo>,
+    imports: Vec<ImportInfo>,
+}
+
+fn walk_py_node(
+    ctx: &mut PyWalkContext<'_>,
+    node: tree_sitter::Node,
+    parent_class: Option<&str>,
+    depth: usize,
+) {
+    if depth > MAX_DEPTH {
+        return;
+    }
+
+    let kind = node.kind();
+
+    match kind {
+        "function_definition" => {
+            if let Some(name) = get_child_text(&node, "name", ctx.src) {
+                let sym_kind = if parent_class.is_some() {
+                    SymbolKind::Method
+                } else {
+                    SymbolKind::Function
+                };
+                ctx.symbols.push(SymbolInfo {
+                    name,
+                    kind: sym_kind,
+                    file_path: ctx.file_path.to_path_buf(),
+                    line_start: node.start_position().row + 1,
+                    line_end: node.end_position().row + 1,
+                    parent: parent_class.map(String::from),
+                    is_exported: false,
+                });
+            }
+            return;
+        }
+        "class_definition" => {
+            let class_name = get_child_text(&node, "name", ctx.src);
+            if let Some(ref name) = class_name {
+                ctx.symbols.push(SymbolInfo {
+                    name: name.clone(),
+                    kind: SymbolKind::Class,
+                    file_path: ctx.file_path.to_path_buf(),
+                    line_start: node.start_position().row + 1,
+                    line_end: node.end_position().row + 1,
+                    parent: parent_class.map(String::from),
+                    is_exported: false,
+                });
+            }
+            let cname = class_name.as_deref();
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                walk_py_node(ctx, child, cname, depth + 1);
+            }
+            return;
+        }
+        "import_statement" => {
+            extract_py_import(ctx, &node);
+        }
+        "import_from_statement" => {
+            extract_py_from_import(ctx, &node);
+        }
+        _ => {}
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        walk_py_node(ctx, child, parent_class, depth + 1);
+    }
+}
+
+fn extract_py_import(ctx: &mut PyWalkContext<'_>, node: &tree_sitter::Node) {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "dotted_name"
+            && let Ok(text) = child.utf8_text(ctx.src)
+        {
+            ctx.imports.push(ImportInfo {
+                source: text.to_string(),
+                imported_names: vec![text.to_string()],
+                file_path: ctx.file_path.to_path_buf(),
+            });
+        }
+    }
+}
+
+fn extract_py_from_import(ctx: &mut PyWalkContext<'_>, node: &tree_sitter::Node) {
+    let mut source_module = String::new();
+    let mut imported_names = Vec::new();
+
+    if let Some(module_node) = node.child_by_field_name("module_name")
+        && let Ok(text) = module_node.utf8_text(ctx.src)
+    {
+        source_module = text.to_string();
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "import_prefix" {
+            continue;
+        }
+        collect_py_import_names(&child, ctx.src, &mut imported_names);
+    }
+
+    if !source_module.is_empty() {
+        ctx.imports.push(ImportInfo {
+            source: source_module,
+            imported_names,
+            file_path: ctx.file_path.to_path_buf(),
+        });
+    }
+}
+
+fn collect_py_import_names(node: &tree_sitter::Node, src: &[u8], names: &mut Vec<String>) {
+    match node.kind() {
+        "dotted_name" => {
+            if let Ok(text) = node.utf8_text(src) {
+                names.push(text.to_string());
+            }
+        }
+        "aliased_import" => {
+            if let Some(name_node) = node.child_by_field_name("name")
+                && let Ok(text) = name_node.utf8_text(src)
+            {
+                names.push(text.to_string());
+            }
+        }
+        _ => {}
+    }
+}

--- a/src/parser/typescript.rs
+++ b/src/parser/typescript.rs
@@ -1,0 +1,235 @@
+use std::path::Path;
+
+use crate::parser::code::{
+    CodeParseError, CodeParseResult, ImportInfo, MAX_DEPTH, SymbolInfo, SymbolKind, get_child_text,
+    parse_with_tree_sitter,
+};
+
+/// Parse TypeScript source code and extract symbols and imports.
+pub fn parse_typescript_content(
+    source: &str,
+    file_path: &Path,
+) -> Result<CodeParseResult, CodeParseError> {
+    let language: tree_sitter::Language = tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into();
+    parse_ts_like(source, file_path, &language)
+}
+
+/// Parse TSX source code and extract symbols and imports.
+pub fn parse_tsx_content(
+    source: &str,
+    file_path: &Path,
+) -> Result<CodeParseResult, CodeParseError> {
+    let language: tree_sitter::Language = tree_sitter_typescript::LANGUAGE_TSX.into();
+    parse_ts_like(source, file_path, &language)
+}
+
+struct TsWalkContext<'a> {
+    src: &'a [u8],
+    file_path: &'a Path,
+    symbols: Vec<SymbolInfo>,
+    imports: Vec<ImportInfo>,
+}
+
+fn parse_ts_like(
+    source: &str,
+    file_path: &Path,
+    language: &tree_sitter::Language,
+) -> Result<CodeParseResult, CodeParseError> {
+    let tree = parse_with_tree_sitter(source, language)?;
+    let root = tree.root_node();
+
+    let mut ctx = TsWalkContext {
+        src: source.as_bytes(),
+        file_path,
+        symbols: Vec::new(),
+        imports: Vec::new(),
+    };
+
+    walk_ts_node(&mut ctx, root, false, None, 0);
+
+    Ok(CodeParseResult {
+        file_path: file_path.to_path_buf(),
+        symbols: ctx.symbols,
+        imports: ctx.imports,
+    })
+}
+
+fn walk_ts_node(
+    ctx: &mut TsWalkContext<'_>,
+    node: tree_sitter::Node,
+    is_exported: bool,
+    parent_class: Option<&str>,
+    depth: usize,
+) {
+    if depth > MAX_DEPTH {
+        return;
+    }
+
+    let kind = node.kind();
+
+    match kind {
+        "export_statement" => {
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                walk_ts_node(ctx, child, true, parent_class, depth + 1);
+            }
+            return;
+        }
+        "function_declaration" => {
+            if let Some(name) = get_child_text(&node, "name", ctx.src) {
+                ctx.symbols.push(SymbolInfo {
+                    name,
+                    kind: SymbolKind::Function,
+                    file_path: ctx.file_path.to_path_buf(),
+                    line_start: node.start_position().row + 1,
+                    line_end: node.end_position().row + 1,
+                    parent: parent_class.map(String::from),
+                    is_exported,
+                });
+            }
+        }
+        "class_declaration" => {
+            let class_name = get_child_text(&node, "name", ctx.src);
+            if let Some(ref name) = class_name {
+                ctx.symbols.push(SymbolInfo {
+                    name: name.clone(),
+                    kind: SymbolKind::Class,
+                    file_path: ctx.file_path.to_path_buf(),
+                    line_start: node.start_position().row + 1,
+                    line_end: node.end_position().row + 1,
+                    parent: parent_class.map(String::from),
+                    is_exported,
+                });
+            }
+            let cname = class_name.as_deref();
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                walk_ts_node(ctx, child, false, cname, depth + 1);
+            }
+            return;
+        }
+        "method_definition" => {
+            if let Some(name) = get_child_text(&node, "name", ctx.src) {
+                ctx.symbols.push(SymbolInfo {
+                    name,
+                    kind: SymbolKind::Method,
+                    file_path: ctx.file_path.to_path_buf(),
+                    line_start: node.start_position().row + 1,
+                    line_end: node.end_position().row + 1,
+                    parent: parent_class.map(String::from),
+                    is_exported: false,
+                });
+            }
+        }
+        "lexical_declaration" => {
+            extract_arrow_functions(ctx, &node, is_exported, parent_class);
+            return;
+        }
+        "import_statement" => {
+            extract_ts_import(ctx, &node);
+        }
+        _ => {}
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        walk_ts_node(ctx, child, is_exported, parent_class, depth + 1);
+    }
+}
+
+fn extract_arrow_functions(
+    ctx: &mut TsWalkContext<'_>,
+    node: &tree_sitter::Node,
+    is_exported: bool,
+    parent_class: Option<&str>,
+) {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "variable_declarator" {
+            let name = get_child_text(&child, "name", ctx.src);
+            let has_arrow = child_has_kind(&child, "arrow_function");
+            if let (Some(name), true) = (name, has_arrow) {
+                ctx.symbols.push(SymbolInfo {
+                    name,
+                    kind: SymbolKind::Function,
+                    file_path: ctx.file_path.to_path_buf(),
+                    line_start: child.start_position().row + 1,
+                    line_end: child.end_position().row + 1,
+                    parent: parent_class.map(String::from),
+                    is_exported,
+                });
+            }
+        }
+    }
+}
+
+fn child_has_kind(node: &tree_sitter::Node, target_kind: &str) -> bool {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == target_kind {
+            return true;
+        }
+        let mut inner_cursor = child.walk();
+        for inner in child.children(&mut inner_cursor) {
+            if inner.kind() == target_kind {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn extract_ts_import(ctx: &mut TsWalkContext<'_>, node: &tree_sitter::Node) {
+    let mut source_module = String::new();
+    let mut imported_names = Vec::new();
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        match child.kind() {
+            "string" => {
+                if let Ok(text) = child.utf8_text(ctx.src) {
+                    source_module = text.trim_matches(|c| c == '\'' || c == '"').to_string();
+                }
+            }
+            "import_clause" => {
+                collect_import_names(&child, ctx.src, &mut imported_names);
+            }
+            _ => {}
+        }
+    }
+
+    if !source_module.is_empty() {
+        ctx.imports.push(ImportInfo {
+            source: source_module,
+            imported_names,
+            file_path: ctx.file_path.to_path_buf(),
+        });
+    }
+}
+
+fn collect_import_names(node: &tree_sitter::Node, src: &[u8], names: &mut Vec<String>) {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        match child.kind() {
+            "identifier" => {
+                if let Ok(text) = child.utf8_text(src) {
+                    names.push(text.to_string());
+                }
+            }
+            "named_imports" => {
+                let mut inner_cursor = child.walk();
+                for inner in child.children(&mut inner_cursor) {
+                    if inner.kind() == "import_specifier"
+                        && let Some(name_node) = inner.child_by_field_name("name")
+                        && let Ok(text) = name_node.utf8_text(src)
+                    {
+                        names.push(text.to_string());
+                    }
+                }
+            }
+            _ => {
+                collect_import_names(&child, src, names);
+            }
+        }
+    }
+}

--- a/tests/parser_python.rs
+++ b/tests/parser_python.rs
@@ -1,0 +1,201 @@
+use commandindex::parser::code::{SymbolKind, parse_code_file};
+use commandindex::parser::python::parse_python_content;
+use std::io::Write;
+use std::path::Path;
+use tempfile::NamedTempFile;
+
+#[test]
+fn test_parse_simple_function() {
+    let source = r#"
+def greet(name):
+    return f"Hello, {name}"
+"#;
+    let result = parse_python_content(source, Path::new("test.py")).unwrap();
+    assert_eq!(result.symbols.len(), 1);
+    assert_eq!(result.symbols[0].name, "greet");
+    assert_eq!(result.symbols[0].kind, SymbolKind::Function);
+    assert!(!result.symbols[0].is_exported);
+}
+
+#[test]
+fn test_parse_class_with_methods() {
+    let source = r#"
+class Calculator:
+    def add(self, a, b):
+        return a + b
+
+    def subtract(self, a, b):
+        return a - b
+"#;
+    let result = parse_python_content(source, Path::new("test.py")).unwrap();
+
+    let class = result.symbols.iter().find(|s| s.kind == SymbolKind::Class);
+    assert!(class.is_some());
+    assert_eq!(class.unwrap().name, "Calculator");
+
+    let methods: Vec<_> = result
+        .symbols
+        .iter()
+        .filter(|s| s.kind == SymbolKind::Method)
+        .collect();
+    assert_eq!(methods.len(), 2);
+    assert_eq!(methods[0].name, "add");
+    assert_eq!(methods[0].parent.as_deref(), Some("Calculator"));
+    assert_eq!(methods[1].name, "subtract");
+    assert_eq!(methods[1].parent.as_deref(), Some("Calculator"));
+}
+
+#[test]
+fn test_parse_import_statement() {
+    let source = r#"
+import os
+import sys
+"#;
+    let result = parse_python_content(source, Path::new("test.py")).unwrap();
+    assert_eq!(result.imports.len(), 2);
+    assert_eq!(result.imports[0].source, "os");
+    assert_eq!(result.imports[1].source, "sys");
+}
+
+#[test]
+fn test_parse_from_import_statement() {
+    let source = r#"
+from pathlib import Path, PurePath
+from os import getcwd
+"#;
+    let result = parse_python_content(source, Path::new("test.py")).unwrap();
+    assert_eq!(result.imports.len(), 2);
+
+    let pathlib_import = result.imports.iter().find(|i| i.source == "pathlib");
+    assert!(pathlib_import.is_some());
+    let pathlib_import = pathlib_import.unwrap();
+    assert!(pathlib_import.imported_names.contains(&"Path".to_string()));
+    assert!(
+        pathlib_import
+            .imported_names
+            .contains(&"PurePath".to_string())
+    );
+}
+
+#[test]
+fn test_parse_nested_class() {
+    let source = r#"
+class Outer:
+    class Inner:
+        def method(self):
+            pass
+"#;
+    let result = parse_python_content(source, Path::new("test.py")).unwrap();
+
+    let classes: Vec<_> = result
+        .symbols
+        .iter()
+        .filter(|s| s.kind == SymbolKind::Class)
+        .collect();
+    assert!(classes.len() >= 2);
+}
+
+#[test]
+fn test_parse_empty_file() {
+    let source = "";
+    let result = parse_python_content(source, Path::new("test.py")).unwrap();
+    assert!(result.symbols.is_empty());
+    assert!(result.imports.is_empty());
+}
+
+#[test]
+fn test_parse_syntax_error() {
+    let source = r#"
+def broken(::
+    pass pass pass
+"#;
+    let result = parse_python_content(source, Path::new("test.py"));
+    assert!(result.is_ok()); // tree-sitter is error-tolerant
+}
+
+#[test]
+fn test_line_numbers_1_indexed() {
+    let source = "def first():\n    pass\ndef second():\n    pass";
+    let result = parse_python_content(source, Path::new("test.py")).unwrap();
+    assert_eq!(result.symbols[0].name, "first");
+    assert_eq!(result.symbols[0].line_start, 1);
+    assert_eq!(result.symbols[1].name, "second");
+    assert_eq!(result.symbols[1].line_start, 3);
+}
+
+#[test]
+fn test_file_path_preserved() {
+    let source = "def test():\n    pass";
+    let path = Path::new("src/utils/helper.py");
+    let result = parse_python_content(source, path).unwrap();
+    assert_eq!(result.file_path, path);
+    assert_eq!(result.symbols[0].file_path, path);
+}
+
+#[test]
+fn test_multiple_top_level_functions() {
+    let source = r#"
+def func_a():
+    pass
+
+def func_b():
+    pass
+
+def func_c():
+    pass
+"#;
+    let result = parse_python_content(source, Path::new("test.py")).unwrap();
+    let functions: Vec<_> = result
+        .symbols
+        .iter()
+        .filter(|s| s.kind == SymbolKind::Function)
+        .collect();
+    assert_eq!(functions.len(), 3);
+}
+
+#[test]
+fn test_is_exported_always_false() {
+    let source = r#"
+def public_func():
+    pass
+
+class MyClass:
+    def method(self):
+        pass
+"#;
+    let result = parse_python_content(source, Path::new("test.py")).unwrap();
+    for sym in &result.symbols {
+        assert!(!sym.is_exported);
+    }
+}
+
+#[test]
+fn test_nested_function_inside_function() {
+    let source = r#"
+def outer():
+    def inner():
+        return 42
+    return inner()
+"#;
+    let result = parse_python_content(source, Path::new("test.py")).unwrap();
+    // Python parser returns early on function_definition, so inner is not traversed.
+    // At minimum, outer should be detected.
+    let functions: Vec<_> = result
+        .symbols
+        .iter()
+        .filter(|s| s.kind == SymbolKind::Function)
+        .collect();
+    assert!(!functions.is_empty());
+    let names: Vec<&str> = functions.iter().map(|f| f.name.as_str()).collect();
+    assert!(names.contains(&"outer"));
+}
+
+#[test]
+fn test_parse_code_file_py_dispatch() {
+    let mut file = NamedTempFile::with_suffix(".py").unwrap();
+    writeln!(file, "def greet():\n    pass").unwrap();
+    let result = parse_code_file(file.path()).unwrap();
+    assert_eq!(result.symbols.len(), 1);
+    assert_eq!(result.symbols[0].name, "greet");
+    assert_eq!(result.symbols[0].kind, SymbolKind::Function);
+}

--- a/tests/parser_typescript.rs
+++ b/tests/parser_typescript.rs
@@ -1,0 +1,241 @@
+use commandindex::parser::code::{SymbolKind, parse_code_file};
+use commandindex::parser::typescript::{parse_tsx_content, parse_typescript_content};
+use std::io::Write;
+use std::path::Path;
+use tempfile::NamedTempFile;
+
+#[test]
+fn test_parse_simple_function() {
+    let source = r#"
+function greet(name: string): string {
+    return `Hello, ${name}`;
+}
+"#;
+    let result = parse_typescript_content(source, Path::new("test.ts")).unwrap();
+    assert_eq!(result.symbols.len(), 1);
+    assert_eq!(result.symbols[0].name, "greet");
+    assert_eq!(result.symbols[0].kind, SymbolKind::Function);
+    assert!(!result.symbols[0].is_exported);
+}
+
+#[test]
+fn test_parse_exported_function() {
+    let source = r#"
+export function add(a: number, b: number): number {
+    return a + b;
+}
+"#;
+    let result = parse_typescript_content(source, Path::new("test.ts")).unwrap();
+    assert_eq!(result.symbols.len(), 1);
+    assert_eq!(result.symbols[0].name, "add");
+    assert_eq!(result.symbols[0].kind, SymbolKind::Function);
+    assert!(result.symbols[0].is_exported);
+}
+
+#[test]
+fn test_parse_class_with_methods() {
+    let source = r#"
+class Calculator {
+    add(a: number, b: number): number {
+        return a + b;
+    }
+
+    subtract(a: number, b: number): number {
+        return a - b;
+    }
+}
+"#;
+    let result = parse_typescript_content(source, Path::new("test.ts")).unwrap();
+
+    let class = result.symbols.iter().find(|s| s.kind == SymbolKind::Class);
+    assert!(class.is_some());
+    assert_eq!(class.unwrap().name, "Calculator");
+
+    let methods: Vec<_> = result
+        .symbols
+        .iter()
+        .filter(|s| s.kind == SymbolKind::Method)
+        .collect();
+    assert_eq!(methods.len(), 2);
+    assert_eq!(methods[0].name, "add");
+    assert_eq!(methods[0].parent.as_deref(), Some("Calculator"));
+    assert_eq!(methods[1].name, "subtract");
+    assert_eq!(methods[1].parent.as_deref(), Some("Calculator"));
+}
+
+#[test]
+fn test_parse_exported_class() {
+    let source = r#"
+export class Logger {
+    log(msg: string): void {
+        console.log(msg);
+    }
+}
+"#;
+    let result = parse_typescript_content(source, Path::new("test.ts")).unwrap();
+
+    let class = result.symbols.iter().find(|s| s.kind == SymbolKind::Class);
+    assert!(class.is_some());
+    assert!(class.unwrap().is_exported);
+}
+
+#[test]
+fn test_parse_imports() {
+    let source = r#"
+import { readFile, writeFile } from 'fs';
+import path from 'path';
+"#;
+    let result = parse_typescript_content(source, Path::new("test.ts")).unwrap();
+    assert!(!result.imports.is_empty());
+
+    let fs_import = result.imports.iter().find(|i| i.source == "fs");
+    assert!(fs_import.is_some());
+    let fs_import = fs_import.unwrap();
+    assert!(fs_import.imported_names.contains(&"readFile".to_string()));
+    assert!(fs_import.imported_names.contains(&"writeFile".to_string()));
+}
+
+#[test]
+fn test_parse_arrow_function() {
+    let source = r#"
+const double = (x: number): number => x * 2;
+"#;
+    let result = parse_typescript_content(source, Path::new("test.ts")).unwrap();
+    assert_eq!(result.symbols.len(), 1);
+    assert_eq!(result.symbols[0].name, "double");
+    assert_eq!(result.symbols[0].kind, SymbolKind::Function);
+}
+
+#[test]
+fn test_parse_exported_arrow_function() {
+    let source = r#"
+export const multiply = (a: number, b: number): number => a * b;
+"#;
+    let result = parse_typescript_content(source, Path::new("test.ts")).unwrap();
+    assert_eq!(result.symbols.len(), 1);
+    assert_eq!(result.symbols[0].name, "multiply");
+    assert!(result.symbols[0].is_exported);
+}
+
+#[test]
+fn test_parse_empty_file() {
+    let source = "";
+    let result = parse_typescript_content(source, Path::new("test.ts")).unwrap();
+    assert!(result.symbols.is_empty());
+    assert!(result.imports.is_empty());
+}
+
+#[test]
+fn test_parse_syntax_error_file() {
+    let source = r#"
+function {{{ broken syntax
+"#;
+    // tree-sitter is error-tolerant, so this should still return a result
+    let result = parse_typescript_content(source, Path::new("test.ts"));
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_line_numbers_are_1_indexed() {
+    let source = r#"function first() {}
+function second() {}
+function third() {}"#;
+    let result = parse_typescript_content(source, Path::new("test.ts")).unwrap();
+    assert_eq!(result.symbols[0].name, "first");
+    assert_eq!(result.symbols[0].line_start, 1);
+    assert_eq!(result.symbols[1].name, "second");
+    assert_eq!(result.symbols[1].line_start, 2);
+    assert_eq!(result.symbols[2].name, "third");
+    assert_eq!(result.symbols[2].line_start, 3);
+}
+
+#[test]
+fn test_file_path_is_preserved() {
+    let source = "function test() {}";
+    let path = Path::new("src/utils/helper.ts");
+    let result = parse_typescript_content(source, path).unwrap();
+    assert_eq!(result.file_path, path);
+    assert_eq!(result.symbols[0].file_path, path);
+}
+
+#[test]
+fn test_tsx_parser() {
+    let source = r#"
+import React from 'react';
+
+export function App(): JSX.Element {
+    return <div>Hello</div>;
+}
+"#;
+    let result = parse_tsx_content(source, Path::new("app.tsx")).unwrap();
+    let func = result.symbols.iter().find(|s| s.name == "App");
+    assert!(func.is_some());
+    assert_eq!(func.unwrap().kind, SymbolKind::Function);
+    assert!(func.unwrap().is_exported);
+}
+
+#[test]
+fn test_multiple_imports() {
+    let source = r#"
+import { useState, useEffect } from 'react';
+import axios from 'axios';
+import { Config } from './config';
+"#;
+    let result = parse_typescript_content(source, Path::new("test.ts")).unwrap();
+    assert_eq!(result.imports.len(), 3);
+}
+
+#[test]
+fn test_nested_function_inside_function() {
+    let source = r#"
+function outer() {
+    function inner() {
+        return 42;
+    }
+    return inner();
+}
+"#;
+    let result = parse_typescript_content(source, Path::new("test.ts")).unwrap();
+    let functions: Vec<_> = result
+        .symbols
+        .iter()
+        .filter(|s| s.kind == SymbolKind::Function)
+        .collect();
+    // Both outer and inner should be extracted
+    assert!(functions.len() >= 2);
+    let names: Vec<&str> = functions.iter().map(|f| f.name.as_str()).collect();
+    assert!(names.contains(&"outer"));
+    assert!(names.contains(&"inner"));
+}
+
+#[test]
+fn test_parse_code_file_ts_dispatch() {
+    let mut file = NamedTempFile::with_suffix(".ts").unwrap();
+    writeln!(file, "export function hello(): string {{ return 'hi'; }}").unwrap();
+    let result = parse_code_file(file.path()).unwrap();
+    assert_eq!(result.symbols.len(), 1);
+    assert_eq!(result.symbols[0].name, "hello");
+    assert!(result.symbols[0].is_exported);
+}
+
+#[test]
+fn test_parse_code_file_tsx_dispatch() {
+    let mut file = NamedTempFile::with_suffix(".tsx").unwrap();
+    writeln!(
+        file,
+        "import React from 'react';\nexport function App() {{ return <div />; }}"
+    )
+    .unwrap();
+    let result = parse_code_file(file.path()).unwrap();
+    let func = result.symbols.iter().find(|s| s.name == "App");
+    assert!(func.is_some());
+    assert!(func.unwrap().is_exported);
+}
+
+#[test]
+fn test_parse_code_file_unsupported_extension() {
+    let mut file = NamedTempFile::with_suffix(".rb").unwrap();
+    writeln!(file, "def hello; end").unwrap();
+    let result = parse_code_file(file.path());
+    assert!(result.is_err());
+}


### PR DESCRIPTION
## Summary
- TypeScript/TSX・Pythonのソースコード解析パーサー
- 関数・クラス・メソッド・import抽出
- 共通型定義（SymbolInfo, ImportInfo, CodeParseResult）
- 1037行の新規コード

Closes #35
🤖 Generated with [Claude Code](https://claude.com/claude-code)