### PR TITLE
feat: SQLite補助ストア（symbols.db）基盤構築

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,6 +419,7 @@ dependencies = [
  "lindera",
  "lindera-tantivy",
  "predicates",
+ "rusqlite",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -787,6 +800,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastdivide"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -987,6 +1012,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1001,6 +1035,15 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -1406,6 +1449,17 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2234,6 +2288,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+dependencies = [
+ "bitflags 2.11.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -3173,6 +3241,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ colored = "2"
 tree-sitter = "0.26"
 tree-sitter-typescript = "0.23"
 tree-sitter-python = "0.25"
+rusqlite = { version = "0.31", features = ["bundled"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -3,12 +3,14 @@ pub mod manifest;
 pub mod reader;
 pub mod schema;
 pub mod state;
+pub mod symbol_store;
 pub mod writer;
 
 use std::path::{Path, PathBuf};
 
 const COMMANDINDEX_DIR: &str = ".commandindex";
 const TANTIVY_DIR: &str = "tantivy";
+const SYMBOLS_DB_FILE: &str = "symbols.db";
 
 /// 対象ファイル拡張子（Phase 1: Markdown のみ）
 // TODO: Phase 2 で cli/index.rs のハードコードをこの定数に統合すること
@@ -22,4 +24,9 @@ pub fn index_dir(base_path: &Path) -> PathBuf {
 /// `.commandindex` ディレクトリのパスを返す
 pub fn commandindex_dir(base_path: &Path) -> PathBuf {
     base_path.join(COMMANDINDEX_DIR)
+}
+
+/// `.commandindex/symbols.db` のパスを返す
+pub fn symbol_db_path(base_path: &Path) -> PathBuf {
+    commandindex_dir(base_path).join(SYMBOLS_DB_FILE)
 }

--- a/src/indexer/symbol_store.rs
+++ b/src/indexer/symbol_store.rs
@@ -1,0 +1,524 @@
+use std::fmt;
+use std::path::Path;
+
+use rusqlite::{Connection, params};
+
+const CURRENT_SYMBOL_SCHEMA_VERSION: u32 = 1;
+
+// ---------------------------------------------------------------------------
+// Data types
+// ---------------------------------------------------------------------------
+
+/// A single code symbol (function, struct, method, etc.) stored in the symbol database.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SymbolInfo {
+    pub id: Option<i64>,
+    pub name: String,
+    pub kind: String,
+    pub file_path: String,
+    pub line_start: u32,
+    pub line_end: u32,
+    pub parent_symbol_id: Option<i64>,
+    pub file_hash: String,
+}
+
+/// An import / dependency record linking a source file to the module it imports.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ImportInfo {
+    pub id: Option<i64>,
+    pub source_file: String,
+    pub target_module: String,
+    pub imported_names: Option<String>,
+    pub file_hash: String,
+}
+
+// ---------------------------------------------------------------------------
+// Row mapping helpers
+// ---------------------------------------------------------------------------
+
+/// Map a SQLite row to a [`SymbolInfo`]. The row must contain columns in the
+/// order: id, name, kind, file_path, line_start, line_end, parent_symbol_id, file_hash.
+fn symbol_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SymbolInfo> {
+    Ok(SymbolInfo {
+        id: Some(row.get(0)?),
+        name: row.get(1)?,
+        kind: row.get(2)?,
+        file_path: row.get(3)?,
+        line_start: row.get(4)?,
+        line_end: row.get(5)?,
+        parent_symbol_id: row.get(6)?,
+        file_hash: row.get(7)?,
+    })
+}
+
+/// Map a SQLite row to an [`ImportInfo`]. The row must contain columns in the
+/// order: id, source_file, target_module, imported_names, file_hash.
+fn import_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<ImportInfo> {
+    Ok(ImportInfo {
+        id: Some(row.get(0)?),
+        source_file: row.get(1)?,
+        target_module: row.get(2)?,
+        imported_names: row.get(3)?,
+        file_hash: row.get(4)?,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+/// Errors that can occur when operating on the symbol store.
+#[derive(Debug)]
+pub enum SymbolStoreError {
+    Sqlite(rusqlite::Error),
+    Io(std::io::Error),
+    SchemaVersionMismatch { expected: u32, found: u32 },
+}
+
+impl fmt::Display for SymbolStoreError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Sqlite(e) => write!(f, "SQLite error: {e}"),
+            Self::Io(e) => write!(f, "IO error: {e}"),
+            Self::SchemaVersionMismatch { expected, found } => {
+                write!(
+                    f,
+                    "Schema version mismatch: expected {expected}, found {found}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for SymbolStoreError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Sqlite(e) => Some(e),
+            Self::Io(e) => Some(e),
+            Self::SchemaVersionMismatch { .. } => None,
+        }
+    }
+}
+
+impl From<rusqlite::Error> for SymbolStoreError {
+    fn from(e: rusqlite::Error) -> Self {
+        Self::Sqlite(e)
+    }
+}
+
+impl From<std::io::Error> for SymbolStoreError {
+    fn from(e: std::io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SymbolStore
+// ---------------------------------------------------------------------------
+
+/// SQLite-backed store for code symbols and dependency (import) records.
+#[derive(Debug)]
+pub struct SymbolStore {
+    conn: Connection,
+}
+
+impl SymbolStore {
+    /// Open (or create) a symbol store backed by the given file path.
+    pub fn open(db_path: &Path) -> Result<Self, SymbolStoreError> {
+        let conn = Connection::open(db_path)?;
+        conn.execute_batch("PRAGMA foreign_keys = ON;")?;
+
+        // Check schema version only when schema_meta table already exists.
+        let table_exists: bool = conn.query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='schema_meta'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )? > 0;
+
+        if table_exists {
+            let version: u32 = conn.query_row(
+                "SELECT value FROM schema_meta WHERE key = 'schema_version'",
+                [],
+                |row| {
+                    let v: String = row.get(0)?;
+                    Ok(v.parse::<u32>().unwrap_or(0))
+                },
+            )?;
+            if version != CURRENT_SYMBOL_SCHEMA_VERSION {
+                return Err(SymbolStoreError::SchemaVersionMismatch {
+                    expected: CURRENT_SYMBOL_SCHEMA_VERSION,
+                    found: version,
+                });
+            }
+        }
+
+        Ok(Self { conn })
+    }
+
+    /// Open an in-memory database (for testing).
+    #[cfg(test)]
+    pub fn open_in_memory() -> Result<Self, SymbolStoreError> {
+        let conn = Connection::open_in_memory()?;
+        conn.execute_batch("PRAGMA foreign_keys = ON;")?;
+        Ok(Self { conn })
+    }
+
+    /// Create all required tables and indices (idempotent).
+    pub fn create_tables(&self) -> Result<(), SymbolStoreError> {
+        self.conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS schema_meta (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS symbols (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                file_path TEXT NOT NULL,
+                line_start INTEGER NOT NULL,
+                line_end INTEGER NOT NULL,
+                parent_symbol_id INTEGER REFERENCES symbols(id) ON DELETE CASCADE,
+                file_hash TEXT NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS dependencies (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                source_file TEXT NOT NULL,
+                target_module TEXT NOT NULL,
+                imported_names TEXT,
+                file_hash TEXT NOT NULL
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_symbols_name ON symbols(name);
+            CREATE INDEX IF NOT EXISTS idx_symbols_file ON symbols(file_path);
+            CREATE INDEX IF NOT EXISTS idx_symbols_kind ON symbols(kind);
+            CREATE INDEX IF NOT EXISTS idx_deps_source ON dependencies(source_file);
+            CREATE INDEX IF NOT EXISTS idx_deps_target ON dependencies(target_module);",
+        )?;
+
+        self.conn.execute(
+            "INSERT OR REPLACE INTO schema_meta (key, value) VALUES (?1, ?2)",
+            params!["schema_version", CURRENT_SYMBOL_SCHEMA_VERSION.to_string()],
+        )?;
+
+        Ok(())
+    }
+
+    /// Bulk-insert symbols inside a single transaction.
+    pub fn insert_symbols(&self, symbols: &[SymbolInfo]) -> Result<(), SymbolStoreError> {
+        let tx = self.conn.unchecked_transaction()?;
+        for sym in symbols {
+            tx.execute(
+                "INSERT INTO symbols (name, kind, file_path, line_start, line_end, parent_symbol_id, file_hash)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                params![
+                    sym.name,
+                    sym.kind,
+                    sym.file_path,
+                    sym.line_start,
+                    sym.line_end,
+                    sym.parent_symbol_id,
+                    sym.file_hash,
+                ],
+            )?;
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Bulk-insert dependency (import) records inside a single transaction.
+    pub fn insert_dependencies(&self, deps: &[ImportInfo]) -> Result<(), SymbolStoreError> {
+        let tx = self.conn.unchecked_transaction()?;
+        for dep in deps {
+            tx.execute(
+                "INSERT INTO dependencies (source_file, target_module, imported_names, file_hash)
+                 VALUES (?1, ?2, ?3, ?4)",
+                params![
+                    dep.source_file,
+                    dep.target_module,
+                    dep.imported_names,
+                    dep.file_hash,
+                ],
+            )?;
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Delete all symbols and dependencies that belong to the given file.
+    pub fn delete_by_file(&self, file_path: &str) -> Result<(), SymbolStoreError> {
+        let tx = self.conn.unchecked_transaction()?;
+        tx.execute(
+            "DELETE FROM symbols WHERE file_path = ?1",
+            params![file_path],
+        )?;
+        tx.execute(
+            "DELETE FROM dependencies WHERE source_file = ?1",
+            params![file_path],
+        )?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Find symbols whose name matches exactly.
+    pub fn find_by_name(&self, name: &str) -> Result<Vec<SymbolInfo>, SymbolStoreError> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, name, kind, file_path, line_start, line_end, parent_symbol_id, file_hash
+             FROM symbols WHERE name = ?1",
+        )?;
+        let rows = stmt.query_map(params![name], symbol_from_row)?;
+        rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    }
+
+    /// Find symbols belonging to the given file path.
+    pub fn find_by_file(&self, file_path: &str) -> Result<Vec<SymbolInfo>, SymbolStoreError> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, name, kind, file_path, line_start, line_end, parent_symbol_id, file_hash
+             FROM symbols WHERE file_path = ?1",
+        )?;
+        let rows = stmt.query_map(params![file_path], symbol_from_row)?;
+        rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    }
+
+    /// Find import records whose target module matches exactly.
+    pub fn find_imports_by_target(
+        &self,
+        target_module: &str,
+    ) -> Result<Vec<ImportInfo>, SymbolStoreError> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, source_file, target_module, imported_names, file_hash
+             FROM dependencies WHERE target_module = ?1",
+        )?;
+        let rows = stmt.query_map(params![target_module], import_from_row)?;
+        rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn sample_symbol(name: &str, file_path: &str) -> SymbolInfo {
+        SymbolInfo {
+            id: None,
+            name: name.to_string(),
+            kind: "function".to_string(),
+            file_path: file_path.to_string(),
+            line_start: 1,
+            line_end: 10,
+            parent_symbol_id: None,
+            file_hash: "abc123".to_string(),
+        }
+    }
+
+    fn sample_import(source: &str, target: &str) -> ImportInfo {
+        ImportInfo {
+            id: None,
+            source_file: source.to_string(),
+            target_module: target.to_string(),
+            imported_names: Some("foo, bar".to_string()),
+            file_hash: "abc123".to_string(),
+        }
+    }
+
+    #[test]
+    fn test_open_and_create_tables() {
+        let store = SymbolStore::open_in_memory().unwrap();
+        store.create_tables().unwrap();
+    }
+
+    #[test]
+    fn test_create_tables_idempotent() {
+        let store = SymbolStore::open_in_memory().unwrap();
+        store.create_tables().unwrap();
+        store.create_tables().unwrap();
+    }
+
+    #[test]
+    fn test_insert_and_find_by_name() {
+        let store = SymbolStore::open_in_memory().unwrap();
+        store.create_tables().unwrap();
+
+        let sym = sample_symbol("my_func", "src/main.rs");
+        store.insert_symbols(&[sym]).unwrap();
+
+        let results = store.find_by_name("my_func").unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "my_func");
+        assert_eq!(results[0].file_path, "src/main.rs");
+        assert!(results[0].id.is_some());
+    }
+
+    #[test]
+    fn test_insert_and_find_by_file() {
+        let store = SymbolStore::open_in_memory().unwrap();
+        store.create_tables().unwrap();
+
+        let syms = vec![
+            sample_symbol("func_a", "src/lib.rs"),
+            sample_symbol("func_b", "src/lib.rs"),
+            sample_symbol("func_c", "src/other.rs"),
+        ];
+        store.insert_symbols(&syms).unwrap();
+
+        let results = store.find_by_file("src/lib.rs").unwrap();
+        assert_eq!(results.len(), 2);
+    }
+
+    #[test]
+    fn test_insert_and_find_dependencies() {
+        let store = SymbolStore::open_in_memory().unwrap();
+        store.create_tables().unwrap();
+
+        let deps = vec![
+            sample_import("src/main.rs", "std::io"),
+            sample_import("src/lib.rs", "std::io"),
+        ];
+        store.insert_dependencies(&deps).unwrap();
+
+        let results = store.find_imports_by_target("std::io").unwrap();
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].target_module, "std::io");
+    }
+
+    #[test]
+    fn test_delete_by_file_removes_symbols() {
+        let store = SymbolStore::open_in_memory().unwrap();
+        store.create_tables().unwrap();
+
+        let syms = vec![
+            sample_symbol("func_a", "src/lib.rs"),
+            sample_symbol("func_b", "src/other.rs"),
+        ];
+        store.insert_symbols(&syms).unwrap();
+
+        store.delete_by_file("src/lib.rs").unwrap();
+
+        let results = store.find_by_file("src/lib.rs").unwrap();
+        assert!(results.is_empty());
+
+        let remaining = store.find_by_file("src/other.rs").unwrap();
+        assert_eq!(remaining.len(), 1);
+    }
+
+    #[test]
+    fn test_delete_by_file_removes_dependencies() {
+        let store = SymbolStore::open_in_memory().unwrap();
+        store.create_tables().unwrap();
+
+        let deps = vec![
+            sample_import("src/main.rs", "std::io"),
+            sample_import("src/lib.rs", "serde"),
+        ];
+        store.insert_dependencies(&deps).unwrap();
+
+        store.delete_by_file("src/main.rs").unwrap();
+
+        let results = store.find_imports_by_target("std::io").unwrap();
+        assert!(results.is_empty());
+
+        let remaining = store.find_imports_by_target("serde").unwrap();
+        assert_eq!(remaining.len(), 1);
+    }
+
+    #[test]
+    fn test_delete_by_file_cascade() {
+        let store = SymbolStore::open_in_memory().unwrap();
+        store.create_tables().unwrap();
+
+        // Insert parent symbol
+        let parent = sample_symbol("MyStruct", "src/lib.rs");
+        store.insert_symbols(&[parent]).unwrap();
+
+        // Get parent id
+        let parents = store.find_by_name("MyStruct").unwrap();
+        let parent_id = parents[0].id.unwrap();
+
+        // Insert child symbol referencing parent
+        let child = SymbolInfo {
+            id: None,
+            name: "my_method".to_string(),
+            kind: "method".to_string(),
+            file_path: "src/lib.rs".to_string(),
+            line_start: 5,
+            line_end: 8,
+            parent_symbol_id: Some(parent_id),
+            file_hash: "abc123".to_string(),
+        };
+        store.insert_symbols(&[child]).unwrap();
+
+        // Verify both exist
+        let all = store.find_by_file("src/lib.rs").unwrap();
+        assert_eq!(all.len(), 2);
+
+        // Delete by file removes parent, CASCADE should remove child
+        store.delete_by_file("src/lib.rs").unwrap();
+
+        let remaining = store.find_by_file("src/lib.rs").unwrap();
+        assert!(remaining.is_empty());
+    }
+
+    #[test]
+    fn test_schema_version_check() {
+        let tmp = TempDir::new().unwrap();
+        let db_path = tmp.path().join("symbols.db");
+
+        // Create store and tables
+        {
+            let store = SymbolStore::open(&db_path).unwrap();
+            store.create_tables().unwrap();
+            // Tamper with version
+            store
+                .conn
+                .execute(
+                    "UPDATE schema_meta SET value = ?1 WHERE key = 'schema_version'",
+                    params!["999"],
+                )
+                .unwrap();
+        }
+
+        // Re-open should fail with version mismatch
+        let result = SymbolStore::open(&db_path);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            SymbolStoreError::SchemaVersionMismatch { expected, found } => {
+                assert_eq!(expected, CURRENT_SYMBOL_SCHEMA_VERSION);
+                assert_eq!(found, 999);
+            }
+            other => panic!("Expected SchemaVersionMismatch, got: {other}"),
+        }
+    }
+
+    #[test]
+    fn test_find_nonexistent_returns_empty() {
+        let store = SymbolStore::open_in_memory().unwrap();
+        store.create_tables().unwrap();
+
+        assert!(store.find_by_name("nonexistent").unwrap().is_empty());
+        assert!(store.find_by_file("no/such/file.rs").unwrap().is_empty());
+        assert!(
+            store
+                .find_imports_by_target("no::module")
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn test_open_creates_db_file() {
+        let tmp = TempDir::new().unwrap();
+        let db_path = tmp.path().join("symbols.db");
+
+        assert!(!db_path.exists());
+
+        let _store = SymbolStore::open(&db_path).unwrap();
+
+        assert!(db_path.exists());
+    }
+}


### PR DESCRIPTION
## Summary
- SymbolStore構造体（symbols/dependenciesテーブルCRUD）
- ファイル単位削除（差分更新用）
- スキーマバージョン管理
- 606行の新規コード

Closes #36
🤖 Generated with [Claude Code](https://claude.com/claude-code)