### PR TITLE
feat: ソースコード index/update 統合

### DIFF
--- a/src/cli/index.rs
+++ b/src/cli/index.rs
@@ -3,13 +3,15 @@ use std::path::Path;
 use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Utc};
-use walkdir::WalkDir;
 
-use crate::indexer::SUPPORTED_EXTENSIONS;
 use crate::indexer::diff::{DiffError, detect_changes, scan_files};
-use crate::indexer::manifest::{self, FileEntry, Manifest, ManifestError, to_relative_path_string};
+use crate::indexer::manifest::{
+    self, FileEntry, FileType, Manifest, ManifestError, to_relative_path_string,
+};
 use crate::indexer::state::{IndexState, StateError};
+use crate::indexer::symbol_store::{SymbolStore, SymbolStoreError};
 use crate::indexer::writer::{IndexWriterWrapper, SectionDoc, WriterError};
+use crate::parser::code::{CodeParseError, parse_code_content};
 use crate::parser::ignore::{IgnoreError, IgnoreFilter};
 use crate::parser::markdown::{self, ParseError};
 
@@ -22,6 +24,8 @@ pub enum IndexError {
     Manifest(ManifestError),
     Ignore(IgnoreError),
     Diff(DiffError),
+    CodeParse(CodeParseError),
+    SymbolStore(SymbolStoreError),
     IndexNotFound,
     SchemaVersionMismatch,
     IndexCorrupted(String),
@@ -37,6 +41,8 @@ impl fmt::Display for IndexError {
             IndexError::Manifest(e) => write!(f, "Manifest error: {e}"),
             IndexError::Ignore(e) => write!(f, "Ignore filter error: {e}"),
             IndexError::Diff(e) => write!(f, "Diff error: {e}"),
+            IndexError::CodeParse(e) => write!(f, "Code parse error: {e}"),
+            IndexError::SymbolStore(e) => write!(f, "Symbol store error: {e}"),
             IndexError::IndexNotFound => write!(
                 f,
                 "No index found. Run `commandindex index` to build the index first."
@@ -63,6 +69,8 @@ impl std::error::Error for IndexError {
             IndexError::Manifest(e) => Some(e),
             IndexError::Ignore(e) => Some(e),
             IndexError::Diff(e) => Some(e),
+            IndexError::CodeParse(e) => Some(e),
+            IndexError::SymbolStore(e) => Some(e),
             IndexError::IndexNotFound
             | IndexError::SchemaVersionMismatch
             | IndexError::IndexCorrupted(_) => None,
@@ -112,6 +120,39 @@ impl From<DiffError> for IndexError {
     }
 }
 
+impl From<CodeParseError> for IndexError {
+    fn from(e: CodeParseError) -> Self {
+        IndexError::CodeParse(e)
+    }
+}
+
+impl From<SymbolStoreError> for IndexError {
+    fn from(e: SymbolStoreError) -> Self {
+        IndexError::SymbolStore(e)
+    }
+}
+
+/// コードファイル識別用の heading_level 定数（Markdown の heading_level 1-6 と区別するため 0 を使用）
+const CODE_FILE_HEADING_LEVEL: u64 = 0;
+
+/// parser::code::SymbolInfo を symbol_store::SymbolInfo に変換する
+fn convert_symbol(
+    src: &crate::parser::code::SymbolInfo,
+    file_path: &str,
+    file_hash: &str,
+) -> crate::indexer::symbol_store::SymbolInfo {
+    crate::indexer::symbol_store::SymbolInfo {
+        id: None,
+        name: src.name.clone(),
+        kind: src.kind.to_string(),
+        file_path: file_path.to_string(),
+        line_start: u32::try_from(src.line_start).unwrap_or(u32::MAX),
+        line_end: u32::try_from(src.line_end).unwrap_or(u32::MAX),
+        parent_symbol_id: None,
+        file_hash: file_hash.to_string(),
+    }
+}
+
 pub struct IndexSummary {
     pub scanned: u64,
     pub indexed_sections: u64,
@@ -151,30 +192,30 @@ pub fn run(path: &Path) -> Result<IndexSummary, IndexError> {
     // 2. Load .cmindexignore
     let ignore_filter = IgnoreFilter::from_file(&path.join(".cmindexignore"))?;
 
-    // 3-4. Walk directory, filter .md files, apply ignore rules
-    let mut md_files = Vec::new();
-    let mut ignored: u64 = 0;
+    // 3. Scan files using scan_files() with all supported extensions
+    let scan_result = scan_files(path, &ignore_filter, FileType::all_extensions())?;
+    let ignored = scan_result.ignored_count;
 
-    for entry in WalkDir::new(path)
-        .into_iter()
-        .filter_map(|e| e.ok())
-        .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
-    {
-        let rel_path = entry.path().strip_prefix(path).unwrap_or(entry.path());
-
-        if ignore_filter.is_ignored(rel_path) {
-            ignored += 1;
-        } else {
-            md_files.push(entry.into_path());
-        }
-    }
-
-    // 5. Remove existing tantivy directory if present
+    // 4. Remove existing tantivy directory if present
     let commandindex_dir = crate::indexer::commandindex_dir(path);
     let tantivy_dir = crate::indexer::index_dir(path);
     if tantivy_dir.exists() {
         std::fs::remove_dir_all(&tantivy_dir)?;
     }
+
+    // Ensure .commandindex directory exists before opening SQLite DB
+    std::fs::create_dir_all(&commandindex_dir)?;
+
+    // 5. Initialize SymbolStore: delete old symbols.db + WAL/SHM files, then open fresh
+    let db_path = crate::indexer::symbol_db_path(path);
+    for suffix in &["", "-wal", "-shm"] {
+        let p = db_path.with_extension(format!("db{suffix}"));
+        if p.exists() {
+            let _ = std::fs::remove_file(&p);
+        }
+    }
+    let symbol_store = SymbolStore::open(&db_path)?;
+    symbol_store.create_tables()?;
 
     // 6. Create new tantivy index
     let mut writer = IndexWriterWrapper::open(&tantivy_dir)?;
@@ -184,64 +225,42 @@ pub fn run(path: &Path) -> Result<IndexSummary, IndexError> {
     let mut skipped: u64 = 0;
     let mut manifest = Manifest::new();
 
-    // 7-11. Parse each file and add to index
-    for file_path in &md_files {
+    // 7. Parse each file and add to index using index_file_and_upsert()
+    for file_path in &scan_result.files {
         scanned += 1;
 
-        let doc = match markdown::parse_file(file_path) {
-            Ok(doc) => doc,
-            Err(e) => {
-                eprintln!("Warning: skipping {}: {e}", file_path.display());
-                skipped += 1;
-                continue;
+        let rel_path = to_relative_path_string(file_path, path);
+
+        match index_file_and_upsert(
+            file_path,
+            &rel_path,
+            &mut writer,
+            &mut manifest,
+            Some(&symbol_store),
+        ) {
+            Ok(section_count) => {
+                indexed_sections += section_count;
             }
-        };
-
-        let rel_path = file_path
-            .strip_prefix(path)
-            .unwrap_or(file_path)
-            .to_string_lossy()
-            .to_string();
-
-        let section_count = doc.sections.len() as u64;
-
-        // Add sections to index
-        for section in &doc.sections {
-            let section_doc = section_to_doc(section, &rel_path, doc.frontmatter.as_ref());
-            writer.add_section(&section_doc)?;
+            Err(IndexFileResult::Skipped) => {
+                skipped += 1;
+            }
+            Err(IndexFileResult::Error(e)) => return Err(e),
         }
-        indexed_sections += section_count;
-
-        // Build manifest entry
-        let hash =
-            manifest::compute_file_hash(file_path).unwrap_or_else(|_| "sha256:unknown".to_string());
-
-        let last_modified = std::fs::metadata(file_path)
-            .and_then(|m| m.modified())
-            .map(DateTime::<Utc>::from)
-            .unwrap_or_else(|_| Utc::now());
-
-        manifest.add_entry(FileEntry {
-            path: rel_path,
-            hash,
-            last_modified,
-            sections: section_count,
-        });
     }
 
-    // 12. Commit index
+    // 8. Commit index
     writer.commit()?;
 
-    // 13. Save manifest
+    // 9. Save manifest
     manifest.save(&commandindex_dir)?;
 
-    // 14. Save state
+    // 10. Save state
     let mut state = IndexState::new(path.to_path_buf());
     state.total_files = scanned;
     state.total_sections = indexed_sections;
     state.save(&commandindex_dir)?;
 
-    // 15. Return summary
+    // 11. Return summary
     Ok(IndexSummary {
         scanned,
         indexed_sections,
@@ -268,9 +287,8 @@ enum IndexFileResult {
     Error(IndexError),
 }
 
-/// Parse a file, add its sections to the index, and upsert the manifest entry.
-/// Returns the number of sections indexed, or `IndexFileResult::Skipped` on parse failure.
-fn index_file_and_upsert(
+/// Markdown ファイルのインデックス処理
+fn index_markdown_file(
     file_path: &Path,
     rel_path: &str,
     writer: &mut IndexWriterWrapper,
@@ -279,7 +297,7 @@ fn index_file_and_upsert(
     let doc = match markdown::parse_file(file_path) {
         Ok(doc) => doc,
         Err(e) => {
-            eprintln!("Warning: skipping {}: {e}", file_path.display());
+            eprintln!("Warning: skipping {rel_path}: {e}");
             return Err(IndexFileResult::Skipped);
         }
     };
@@ -304,9 +322,113 @@ fn index_file_and_upsert(
         hash,
         last_modified,
         sections: section_count,
+        file_type: FileType::Markdown,
     });
 
     Ok(section_count)
+}
+
+/// コードファイルのインデックス処理（symbols.db + tantivy）
+fn index_code_file(
+    file_path: &Path,
+    rel_path: &str,
+    writer: &mut IndexWriterWrapper,
+    manifest: &mut Manifest,
+    symbol_store: &SymbolStore,
+    file_type: FileType,
+) -> Result<u64, IndexFileResult> {
+    // 空ファイルスキップ
+    let content = match std::fs::read_to_string(file_path) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Warning: skipping {rel_path}: {e}");
+            return Err(IndexFileResult::Skipped);
+        }
+    };
+    if content.is_empty() {
+        return Ok(0);
+    }
+
+    // tree-sitter パース
+    let result = match parse_code_file(file_path) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Warning: skipping {rel_path}: {e}");
+            return Err(IndexFileResult::Skipped);
+        }
+    };
+
+    let hash =
+        manifest::compute_file_hash(file_path).unwrap_or_else(|_| "sha256:unknown".to_string());
+
+    // symbols.db: delete → insert パターン
+    symbol_store
+        .delete_by_file(rel_path)
+        .map_err(|e| IndexFileResult::Error(e.into()))?;
+
+    let symbols: Vec<_> = result
+        .symbols
+        .iter()
+        .map(|s| convert_symbol(s, rel_path, &hash))
+        .collect();
+
+    if let Err(e) = symbol_store.insert_symbols(&symbols) {
+        eprintln!("Warning: symbol store insert failed for {rel_path}: {e}");
+        return Err(IndexFileResult::Skipped);
+    }
+
+    // tantivy: heading=ファイル名, body=全文
+    let filename = file_path
+        .file_name()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_string();
+    if let Err(e) = writer.add_section(&SectionDoc {
+        path: rel_path.to_string(),
+        heading: filename,
+        body: content,
+        tags: String::new(),
+        heading_level: CODE_FILE_HEADING_LEVEL,
+        line_start: 1,
+    }) {
+        // tantivy add_section 失敗時は symbols.db をロールバック
+        let _ = symbol_store.delete_by_file(rel_path);
+        return Err(IndexFileResult::Error(e.into()));
+    }
+
+    let last_modified = std::fs::metadata(file_path)
+        .and_then(|m| m.modified())
+        .map(DateTime::<Utc>::from)
+        .unwrap_or_else(|_| Utc::now());
+
+    manifest.upsert_entry(FileEntry {
+        path: rel_path.to_string(),
+        hash,
+        last_modified,
+        sections: 1,
+        file_type,
+    });
+
+    Ok(1)
+}
+
+/// ファイル種別に応じてインデックス処理をディスパッチする
+fn index_file_and_upsert(
+    file_path: &Path,
+    rel_path: &str,
+    writer: &mut IndexWriterWrapper,
+    manifest: &mut Manifest,
+    symbol_store: Option<&SymbolStore>,
+) -> Result<u64, IndexFileResult> {
+    let ext = file_path.extension().and_then(|e| e.to_str()).unwrap_or("");
+    match FileType::from_extension(ext) {
+        Some(FileType::Markdown) => index_markdown_file(file_path, rel_path, writer, manifest),
+        Some(ft) if ft.is_code() => {
+            let store = symbol_store.ok_or(IndexFileResult::Skipped)?;
+            index_code_file(file_path, rel_path, writer, manifest, store, ft)
+        }
+        _ => Ok(0),
+    }
 }
 
 pub fn run_incremental(path: &Path) -> Result<IncrementalSummary, IndexError> {
@@ -337,7 +459,7 @@ pub fn run_incremental(path: &Path) -> Result<IncrementalSummary, IndexError> {
     let ignore_filter = IgnoreFilter::from_file(&path.join(".cmindexignore"))?;
 
     // 4. Scan files
-    let scan_result = scan_files(path, &ignore_filter, SUPPORTED_EXTENSIONS)?;
+    let scan_result = scan_files(path, &ignore_filter, FileType::all_extensions())?;
 
     // 5. Load old manifest
     let mut old_manifest = Manifest::load_or_default(&commandindex_dir)?;
@@ -370,6 +492,11 @@ pub fn run_incremental(path: &Path) -> Result<IncrementalSummary, IndexError> {
         }
     };
 
+    // 9. Open SymbolStore (create tables if not yet created)
+    let db_path = crate::indexer::symbol_db_path(path);
+    let symbol_store = SymbolStore::open(&db_path)?;
+    symbol_store.create_tables()?;
+
     let mut added_files: u64 = 0;
     let mut added_sections: u64 = 0;
     let mut modified_files: u64 = 0;
@@ -381,7 +508,7 @@ pub fn run_incremental(path: &Path) -> Result<IncrementalSummary, IndexError> {
     let mut old_deleted_sections: u64 = 0;
     let mut old_modified_sections: u64 = 0;
 
-    // 9. Process deleted files
+    // 10. Process deleted files
     for del_path in &diff_result.deleted {
         let path_str = del_path.to_string_lossy().to_string();
         writer.delete_by_path(&path_str)?;
@@ -389,13 +516,17 @@ pub fn run_incremental(path: &Path) -> Result<IncrementalSummary, IndexError> {
         // Track old sections count
         if let Some(entry) = old_manifest.find_by_path(&path_str) {
             old_deleted_sections += entry.sections;
+            // Delete symbols for code files
+            if entry.file_type.is_code() {
+                symbol_store.delete_by_file(&path_str)?;
+            }
         }
 
         old_manifest.remove_by_path(&path_str);
         deleted_files += 1;
     }
 
-    // 10. Process modified files
+    // 11. Process modified files
     for mod_path in &diff_result.modified {
         let rel_path = to_relative_path_string(mod_path, path);
 
@@ -406,7 +537,13 @@ pub fn run_incremental(path: &Path) -> Result<IncrementalSummary, IndexError> {
 
         writer.delete_by_path(&rel_path)?;
 
-        match index_file_and_upsert(mod_path, &rel_path, &mut writer, &mut old_manifest) {
+        match index_file_and_upsert(
+            mod_path,
+            &rel_path,
+            &mut writer,
+            &mut old_manifest,
+            Some(&symbol_store),
+        ) {
             Ok(section_count) => {
                 modified_files += 1;
                 modified_sections += section_count;
@@ -418,11 +555,17 @@ pub fn run_incremental(path: &Path) -> Result<IncrementalSummary, IndexError> {
         }
     }
 
-    // 11. Process added files
+    // 12. Process added files
     for add_path in &diff_result.added {
         let rel_path = to_relative_path_string(add_path, path);
 
-        match index_file_and_upsert(add_path, &rel_path, &mut writer, &mut old_manifest) {
+        match index_file_and_upsert(
+            add_path,
+            &rel_path,
+            &mut writer,
+            &mut old_manifest,
+            Some(&symbol_store),
+        ) {
             Ok(section_count) => {
                 added_files += 1;
                 added_sections += section_count;
@@ -434,13 +577,13 @@ pub fn run_incremental(path: &Path) -> Result<IncrementalSummary, IndexError> {
         }
     }
 
-    // 12. Commit index
+    // 13. Commit index
     writer.commit()?;
 
-    // 13. Save updated manifest
+    // 14. Save updated manifest
     old_manifest.save(&commandindex_dir)?;
 
-    // 14. Update state (use saturating arithmetic to prevent underflow on corrupted state)
+    // 15. Update state (use saturating arithmetic to prevent underflow on corrupted state)
     state.total_files = state.total_files.saturating_add(added_files);
     if deleted_files > state.total_files {
         eprintln!(
@@ -461,7 +604,7 @@ pub fn run_incremental(path: &Path) -> Result<IncrementalSummary, IndexError> {
     state.touch();
     state.save(&commandindex_dir)?;
 
-    // 15. Return summary
+    // 16. Return summary
     Ok(IncrementalSummary {
         added_files,
         added_sections,
@@ -472,4 +615,88 @@ pub fn run_incremental(path: &Path) -> Result<IncrementalSummary, IndexError> {
         skipped,
         duration: start.elapsed(),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::code::{SymbolInfo as CodeSymbolInfo, SymbolKind};
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_convert_symbol_normal() {
+        let src = CodeSymbolInfo {
+            name: "my_func".to_string(),
+            kind: SymbolKind::Function,
+            file_path: PathBuf::from("src/main.ts"),
+            line_start: 10,
+            line_end: 20,
+            parent: None,
+            is_exported: true,
+        };
+        let result = convert_symbol(&src, "src/main.ts", "sha256:abc");
+        assert_eq!(result.name, "my_func");
+        assert_eq!(result.kind, "Function");
+        assert_eq!(result.file_path, "src/main.ts");
+        assert_eq!(result.line_start, 10);
+        assert_eq!(result.line_end, 20);
+        assert!(result.parent_symbol_id.is_none());
+        assert!(result.id.is_none());
+        assert_eq!(result.file_hash, "sha256:abc");
+    }
+
+    #[test]
+    fn test_convert_symbol_large_line_numbers() {
+        let src = CodeSymbolInfo {
+            name: "big".to_string(),
+            kind: SymbolKind::Class,
+            file_path: PathBuf::from("big.py"),
+            line_start: usize::MAX,
+            line_end: usize::MAX,
+            parent: None,
+            is_exported: false,
+        };
+        let result = convert_symbol(&src, "big.py", "sha256:xyz");
+        assert_eq!(result.line_start, u32::MAX);
+        assert_eq!(result.line_end, u32::MAX);
+    }
+
+    #[test]
+    fn test_code_file_heading_level_is_zero() {
+        assert_eq!(CODE_FILE_HEADING_LEVEL, 0);
+    }
+
+    #[test]
+    fn test_index_error_display_code_parse() {
+        let err = IndexError::CodeParse(CodeParseError::UnsupportedLanguage("rs".to_string()));
+        let msg = format!("{err}");
+        assert!(msg.contains("Code parse error"));
+    }
+
+    #[test]
+    fn test_index_error_display_symbol_store() {
+        let err = IndexError::SymbolStore(SymbolStoreError::SchemaVersionMismatch {
+            expected: 1,
+            found: 2,
+        });
+        let msg = format!("{err}");
+        assert!(msg.contains("Symbol store error"));
+    }
+
+    #[test]
+    fn test_index_error_from_code_parse_error() {
+        let e = CodeParseError::UnsupportedLanguage("go".to_string());
+        let ie: IndexError = e.into();
+        assert!(matches!(ie, IndexError::CodeParse(_)));
+    }
+
+    #[test]
+    fn test_index_error_from_symbol_store_error() {
+        let e = SymbolStoreError::SchemaVersionMismatch {
+            expected: 1,
+            found: 99,
+        };
+        let ie: IndexError = e.into();
+        assert!(matches!(ie, IndexError::SymbolStore(_)));
+    }
 }

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -6,7 +6,9 @@ use clap::ValueEnum;
 use serde::Serialize;
 use walkdir::WalkDir;
 
+use crate::indexer::manifest::{FileType, Manifest};
 use crate::indexer::state::{IndexState, StateError};
+use crate::indexer::symbol_store::SymbolStore;
 use crate::output::strip_control_chars;
 
 /// status コマンドの出力フォーマット
@@ -53,12 +55,22 @@ impl From<StateError> for StatusError {
     }
 }
 
+/// ファイルタイプ別カウント
+#[derive(Debug, Serialize, Default)]
+pub struct FileTypeCounts {
+    pub markdown: u64,
+    pub typescript: u64,
+    pub python: u64,
+}
+
 /// status コマンドの出力情報
 #[derive(Debug, Serialize)]
 pub struct StatusInfo {
     #[serde(flatten)]
     pub state: IndexState,
     pub index_size_bytes: u64,
+    pub file_type_counts: FileTypeCounts,
+    pub symbol_count: u64,
 }
 
 /// ディレクトリサイズを再帰的に計算する
@@ -92,6 +104,36 @@ pub fn format_size(bytes: u64) -> String {
     }
 }
 
+/// Manifest からファイルタイプ別のカウントを集計する
+fn count_file_types(commandindex_dir: &Path) -> FileTypeCounts {
+    let manifest = match Manifest::load_or_default(commandindex_dir) {
+        Ok(m) => m,
+        Err(_) => return FileTypeCounts::default(),
+    };
+
+    let mut counts = FileTypeCounts::default();
+    for entry in &manifest.files {
+        match entry.file_type {
+            FileType::Markdown => counts.markdown += 1,
+            FileType::TypeScript => counts.typescript += 1,
+            FileType::Python => counts.python += 1,
+        }
+    }
+    counts
+}
+
+/// SymbolStore からシンボル数を取得する（DB が存在しない場合は 0）
+fn get_symbol_count(base_path: &Path) -> u64 {
+    let db_path = crate::indexer::symbol_db_path(base_path);
+    if !db_path.exists() {
+        return 0;
+    }
+    match SymbolStore::open(&db_path) {
+        Ok(store) => store.count_all().unwrap_or(0),
+        Err(_) => 0,
+    }
+}
+
 /// status コマンドのメインロジック
 pub fn run(path: &Path, format: StatusFormat, writer: &mut dyn Write) -> Result<(), StatusError> {
     if !path.is_dir() {
@@ -108,10 +150,14 @@ pub fn run(path: &Path, format: StatusFormat, writer: &mut dyn Write) -> Result<
     state.check_schema_version()?;
 
     let index_size_bytes = compute_dir_size(&commandindex_dir);
+    let file_type_counts = count_file_types(&commandindex_dir);
+    let symbol_count = get_symbol_count(path);
 
     let info = StatusInfo {
         state,
         index_size_bytes,
+        file_type_counts,
+        symbol_count,
     };
 
     match format {
@@ -129,6 +175,15 @@ pub fn run(path: &Path, format: StatusFormat, writer: &mut dyn Write) -> Result<
             .ok();
             writeln!(writer, "  Total files:   {}", info.state.total_files).ok();
             writeln!(writer, "  Total sections: {}", info.state.total_sections).ok();
+            writeln!(
+                writer,
+                "  Files by type: Markdown={}, TypeScript={}, Python={}",
+                info.file_type_counts.markdown,
+                info.file_type_counts.typescript,
+                info.file_type_counts.python
+            )
+            .ok();
+            writeln!(writer, "  Symbols:       {}", info.symbol_count).ok();
             writeln!(
                 writer,
                 "  Index size:    {}",

--- a/src/indexer/manifest.rs
+++ b/src/indexer/manifest.rs
@@ -6,6 +6,38 @@ use std::path::Path;
 
 const MANIFEST_FILE: &str = "manifest.json";
 
+/// ファイル種別を表す enum
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum FileType {
+    #[default]
+    Markdown,
+    TypeScript,
+    Python,
+}
+
+impl FileType {
+    /// 拡張子から FileType を判定する
+    pub fn from_extension(ext: &str) -> Option<FileType> {
+        match ext {
+            "md" => Some(FileType::Markdown),
+            "ts" | "tsx" => Some(FileType::TypeScript),
+            "py" => Some(FileType::Python),
+            _ => None,
+        }
+    }
+
+    /// 全サポート拡張子を返す
+    pub fn all_extensions() -> &'static [&'static str] {
+        &["md", "ts", "tsx", "py"]
+    }
+
+    /// コードファイルかどうかを判定（Markdown 以外は全てコード）
+    pub fn is_code(&self) -> bool {
+        !matches!(self, FileType::Markdown)
+    }
+}
+
 #[derive(Debug)]
 pub enum ManifestError {
     Io(std::io::Error),
@@ -48,6 +80,8 @@ pub struct FileEntry {
     pub hash: String,
     pub last_modified: DateTime<Utc>,
     pub sections: u64,
+    #[serde(default)]
+    pub file_type: FileType,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -139,4 +173,87 @@ pub fn compute_file_hash(path: &Path) -> Result<String, std::io::Error> {
     let content = std::fs::read(path)?;
     let hash = Sha256::digest(&content);
     Ok(format!("sha256:{:x}", hash))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- FileType tests ---
+
+    #[test]
+    fn file_type_from_extension_md() {
+        assert_eq!(FileType::from_extension("md"), Some(FileType::Markdown));
+    }
+
+    #[test]
+    fn file_type_from_extension_ts() {
+        assert_eq!(FileType::from_extension("ts"), Some(FileType::TypeScript));
+    }
+
+    #[test]
+    fn file_type_from_extension_tsx() {
+        assert_eq!(FileType::from_extension("tsx"), Some(FileType::TypeScript));
+    }
+
+    #[test]
+    fn file_type_from_extension_py() {
+        assert_eq!(FileType::from_extension("py"), Some(FileType::Python));
+    }
+
+    #[test]
+    fn file_type_from_extension_unknown() {
+        assert_eq!(FileType::from_extension("rs"), None);
+        assert_eq!(FileType::from_extension(""), None);
+    }
+
+    #[test]
+    fn file_type_all_extensions_contains_all() {
+        let exts = FileType::all_extensions();
+        assert!(exts.contains(&"md"));
+        assert!(exts.contains(&"ts"));
+        assert!(exts.contains(&"tsx"));
+        assert!(exts.contains(&"py"));
+    }
+
+    #[test]
+    fn file_type_is_code() {
+        assert!(!FileType::Markdown.is_code());
+        assert!(FileType::TypeScript.is_code());
+        assert!(FileType::Python.is_code());
+    }
+
+    #[test]
+    fn file_type_default_is_markdown() {
+        assert_eq!(FileType::default(), FileType::Markdown);
+    }
+
+    #[test]
+    fn file_entry_serde_backward_compat() {
+        // Old JSON without file_type should deserialize with default (Markdown)
+        let json = r#"{"path":"test.md","hash":"sha256:abc","last_modified":"2024-01-01T00:00:00Z","sections":1}"#;
+        let entry: FileEntry = serde_json::from_str(json).unwrap();
+        assert_eq!(entry.file_type, FileType::Markdown);
+    }
+
+    #[test]
+    fn file_entry_serde_with_file_type() {
+        let json = r#"{"path":"test.ts","hash":"sha256:abc","last_modified":"2024-01-01T00:00:00Z","sections":1,"file_type":"type_script"}"#;
+        let entry: FileEntry = serde_json::from_str(json).unwrap();
+        assert_eq!(entry.file_type, FileType::TypeScript);
+    }
+
+    #[test]
+    fn file_entry_roundtrip_serde() {
+        let entry = FileEntry {
+            path: "src/main.py".to_string(),
+            hash: "sha256:abc".to_string(),
+            last_modified: chrono::Utc::now(),
+            sections: 3,
+            file_type: FileType::Python,
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        let deserialized: FileEntry = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.file_type, FileType::Python);
+    }
 }

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -12,10 +12,6 @@ const COMMANDINDEX_DIR: &str = ".commandindex";
 const TANTIVY_DIR: &str = "tantivy";
 const SYMBOLS_DB_FILE: &str = "symbols.db";
 
-/// 対象ファイル拡張子（Phase 1: Markdown のみ）
-// TODO: Phase 2 で cli/index.rs のハードコードをこの定数に統合すること
-pub const SUPPORTED_EXTENSIONS: &[&str] = &["md"];
-
 /// `.commandindex/tantivy` ディレクトリのパスを返す
 pub fn index_dir(base_path: &Path) -> PathBuf {
     base_path.join(COMMANDINDEX_DIR).join(TANTIVY_DIR)

--- a/src/indexer/reader.rs
+++ b/src/indexer/reader.rs
@@ -208,8 +208,18 @@ impl IndexReaderWrapper {
 }
 
 fn matches_file_type(path: &str, file_type: &str) -> bool {
+    use crate::indexer::manifest::FileType;
+
+    let ext = path.rsplit('.').next().unwrap_or("");
+
     match file_type {
-        "markdown" => path.ends_with(".md"),
+        "markdown" | "md" => ext == "md",
+        "typescript" | "ts" => ext == "ts" || ext == "tsx",
+        "python" | "py" => ext == "py",
+        "code" => {
+            // All code file types (non-Markdown)
+            FileType::from_extension(ext).is_some_and(|ft| ft.is_code())
+        }
         _ => false,
     }
 }

--- a/src/indexer/symbol_store.rs
+++ b/src/indexer/symbol_store.rs
@@ -281,6 +281,14 @@ impl SymbolStore {
         rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
     }
 
+    /// Count all symbols in the store.
+    pub fn count_all(&self) -> Result<u64, SymbolStoreError> {
+        let count: i64 = self
+            .conn
+            .query_row("SELECT COUNT(*) FROM symbols", [], |row| row.get(0))?;
+        Ok(count as u64)
+    }
+
     /// Find import records whose target module matches exactly.
     pub fn find_imports_by_target(
         &self,
@@ -493,6 +501,27 @@ mod tests {
             }
             other => panic!("Expected SchemaVersionMismatch, got: {other}"),
         }
+    }
+
+    #[test]
+    fn test_count_all_empty() {
+        let store = SymbolStore::open_in_memory().unwrap();
+        store.create_tables().unwrap();
+        assert_eq!(store.count_all().unwrap(), 0);
+    }
+
+    #[test]
+    fn test_count_all_after_insert() {
+        let store = SymbolStore::open_in_memory().unwrap();
+        store.create_tables().unwrap();
+
+        let syms = vec![
+            sample_symbol("func_a", "src/lib.rs"),
+            sample_symbol("func_b", "src/lib.rs"),
+            sample_symbol("func_c", "src/other.rs"),
+        ];
+        store.insert_symbols(&syms).unwrap();
+        assert_eq!(store.count_all().unwrap(), 3);
     }
 
     #[test]

--- a/tests/diff_detection.rs
+++ b/tests/diff_detection.rs
@@ -10,8 +10,7 @@ use commandindex::indexer::manifest::{
 };
 use commandindex::parser::ignore::IgnoreFilter;
 
-// Verify SUPPORTED_EXTENSIONS is accessible
-const _: &[&str] = commandindex::indexer::SUPPORTED_EXTENSIONS;
+// FileType is used in make_entry() via commandindex::indexer::manifest::FileType
 
 fn make_entry(path: &str, hash: &str) -> FileEntry {
     FileEntry {
@@ -19,6 +18,7 @@ fn make_entry(path: &str, hash: &str) -> FileEntry {
         hash: hash.to_string(),
         last_modified: chrono::Utc::now(),
         sections: 1,
+        file_type: commandindex::indexer::manifest::FileType::Markdown,
     }
 }
 

--- a/tests/e2e_code_index.rs
+++ b/tests/e2e_code_index.rs
@@ -1,0 +1,382 @@
+mod common;
+
+use std::fs;
+use tempfile::TempDir;
+
+/// Create a test directory with TypeScript, Python, and Markdown files.
+///
+/// ```text
+/// ├── guide.md           (Markdown with tags)
+/// ├── src/
+/// │   ├── main.ts        (TypeScript: function greet, class UserService)
+/// │   ├── utils.py       (Python: function calculate_sum, class DataProcessor)
+/// │   └── empty.ts       (empty file — should be skipped)
+/// └── .cmindexignore     (excludes nothing)
+/// ```
+fn setup_code_dir() -> TempDir {
+    let dir = tempfile::tempdir().expect("create temp dir");
+
+    // Markdown file
+    fs::write(
+        dir.path().join("guide.md"),
+        "\
+---
+tags:
+  - guide
+---
+# Guide
+
+This is a guide document.
+",
+    )
+    .unwrap();
+
+    // TypeScript file
+    fs::create_dir_all(dir.path().join("src")).unwrap();
+    fs::write(
+        dir.path().join("src/main.ts"),
+        "\
+export function greet(name: string): string {
+    return `Hello, ${name}!`;
+}
+
+export class UserService {
+    getUser(id: number) {
+        return { id, name: 'test' };
+    }
+}
+",
+    )
+    .unwrap();
+
+    // Python file
+    fs::write(
+        dir.path().join("src/utils.py"),
+        "\
+def calculate_sum(a, b):
+    return a + b
+
+class DataProcessor:
+    def process(self, data):
+        return data
+",
+    )
+    .unwrap();
+
+    // Empty TypeScript file (should be skipped)
+    fs::write(dir.path().join("src/empty.ts"), "").unwrap();
+
+    dir
+}
+
+#[test]
+fn e2e_code_index_creates_symbols_db() {
+    let dir = setup_code_dir();
+    common::run_index(dir.path());
+
+    assert!(
+        dir.path().join(".commandindex/symbols.db").exists(),
+        "symbols.db should be created after indexing"
+    );
+}
+
+#[test]
+fn e2e_code_index_manifest_contains_code_files() {
+    let dir = setup_code_dir();
+    common::run_index(dir.path());
+
+    let manifest_path = dir.path().join(".commandindex/manifest.json");
+    let content = fs::read_to_string(&manifest_path).unwrap();
+    let manifest: serde_json::Value = serde_json::from_str(&content).unwrap();
+
+    let files = manifest["files"].as_array().unwrap();
+    let paths: Vec<&str> = files.iter().map(|f| f["path"].as_str().unwrap()).collect();
+
+    assert!(
+        paths.contains(&"guide.md"),
+        "manifest should contain guide.md"
+    );
+    assert!(
+        paths.contains(&"src/main.ts"),
+        "manifest should contain src/main.ts"
+    );
+    assert!(
+        paths.contains(&"src/utils.py"),
+        "manifest should contain src/utils.py"
+    );
+
+    // Verify file_type fields
+    for file in files {
+        let path = file["path"].as_str().unwrap();
+        let ft = file["file_type"].as_str().unwrap();
+        match path {
+            "guide.md" => assert_eq!(ft, "markdown"),
+            "src/main.ts" => assert_eq!(ft, "type_script"),
+            "src/utils.py" => assert_eq!(ft, "python"),
+            _ => {} // empty.ts may or may not be present (it's empty, so skipped by code indexer but 0 sections)
+        }
+    }
+}
+
+#[test]
+fn e2e_code_search_typescript() {
+    let dir = setup_code_dir();
+    common::run_index(dir.path());
+
+    // Search for TypeScript content
+    let results = common::run_search_jsonl(dir.path(), "greet");
+    let found = results
+        .iter()
+        .any(|r| r["path"].as_str().is_some_and(|p| p.contains("main.ts")));
+    assert!(
+        found,
+        "search for 'greet' should find main.ts, got: {results:?}"
+    );
+}
+
+#[test]
+fn e2e_code_search_python() {
+    let dir = setup_code_dir();
+    common::run_index(dir.path());
+
+    // Search for Python content
+    let results = common::run_search_jsonl(dir.path(), "calculate_sum");
+    let found = results
+        .iter()
+        .any(|r| r["path"].as_str().is_some_and(|p| p.contains("utils.py")));
+    assert!(
+        found,
+        "search for 'calculate_sum' should find utils.py, got: {results:?}"
+    );
+}
+
+#[test]
+fn e2e_code_search_markdown_still_works() {
+    let dir = setup_code_dir();
+    common::run_index(dir.path());
+
+    // Search for Markdown content
+    let results = common::run_search_jsonl(dir.path(), "guide");
+    let found = results
+        .iter()
+        .any(|r| r["path"].as_str().is_some_and(|p| p.contains("guide.md")));
+    assert!(
+        found,
+        "search for 'guide' should find guide.md, got: {results:?}"
+    );
+}
+
+#[test]
+fn e2e_code_update_add_code_file() {
+    let dir = setup_code_dir();
+    common::run_index(dir.path());
+
+    // Add a new Python file
+    fs::write(
+        dir.path().join("src/new_module.py"),
+        "\
+def new_function_xyz():
+    pass
+",
+    )
+    .unwrap();
+
+    std::thread::sleep(std::time::Duration::from_millis(100));
+
+    // Run update
+    common::run_update(dir.path()).success();
+
+    // Verify new content is searchable
+    let results = common::run_search_jsonl(dir.path(), "new_function_xyz");
+    let found = results.iter().any(|r| {
+        r["path"]
+            .as_str()
+            .is_some_and(|p| p.contains("new_module.py"))
+    });
+    assert!(
+        found,
+        "search for 'new_function_xyz' should find new_module.py after update, got: {results:?}"
+    );
+}
+
+#[test]
+fn e2e_code_update_modify_code_file() {
+    let dir = setup_code_dir();
+    common::run_index(dir.path());
+
+    // Modify existing TypeScript file
+    fs::write(
+        dir.path().join("src/main.ts"),
+        "\
+export function modified_unique_function(): void {
+    console.log('modified');
+}
+",
+    )
+    .unwrap();
+
+    std::thread::sleep(std::time::Duration::from_millis(100));
+
+    // Run update
+    common::run_update(dir.path()).success();
+
+    // Verify new content is searchable
+    let results = common::run_search_jsonl(dir.path(), "modified_unique_function");
+    let found = results
+        .iter()
+        .any(|r| r["path"].as_str().is_some_and(|p| p.contains("main.ts")));
+    assert!(
+        found,
+        "search for 'modified_unique_function' should find main.ts after update, got: {results:?}"
+    );
+
+    // Verify old content (greet) from main.ts is no longer found
+    let results = common::run_search_jsonl(dir.path(), "greet");
+    let old_found = results
+        .iter()
+        .any(|r| r["path"].as_str().is_some_and(|p| p.contains("main.ts")));
+    assert!(
+        !old_found,
+        "search for 'greet' should NOT find main.ts after modification"
+    );
+}
+
+#[test]
+fn e2e_code_update_delete_code_file() {
+    let dir = setup_code_dir();
+    common::run_index(dir.path());
+
+    // Delete the Python file
+    fs::remove_file(dir.path().join("src/utils.py")).unwrap();
+
+    std::thread::sleep(std::time::Duration::from_millis(100));
+
+    // Run update
+    common::run_update(dir.path()).success();
+
+    // Verify deleted content is not found
+    let results = common::run_search_jsonl(dir.path(), "calculate_sum");
+    let found = results
+        .iter()
+        .any(|r| r["path"].as_str().is_some_and(|p| p.contains("utils.py")));
+    assert!(
+        !found,
+        "search for 'calculate_sum' should NOT find utils.py after deletion"
+    );
+}
+
+#[test]
+fn e2e_code_clean_and_reindex() {
+    let dir = setup_code_dir();
+    common::run_index(dir.path());
+
+    // Clean
+    common::cmd()
+        .args(["clean", "--path", dir.path().to_str().unwrap()])
+        .assert()
+        .success();
+
+    assert!(
+        !dir.path().join(".commandindex").exists(),
+        ".commandindex should be removed after clean"
+    );
+
+    // Reindex
+    common::run_index(dir.path());
+
+    // Verify code files are still searchable after reindex
+    let results = common::run_search_jsonl(dir.path(), "greet");
+    let found = results
+        .iter()
+        .any(|r| r["path"].as_str().is_some_and(|p| p.contains("main.ts")));
+    assert!(
+        found,
+        "search for 'greet' should find main.ts after clean + reindex"
+    );
+}
+
+#[test]
+fn e2e_code_empty_file_skipped() {
+    let dir = setup_code_dir();
+    common::run_index(dir.path());
+
+    // Empty file should not produce any search results
+    let results = common::run_search_jsonl(dir.path(), "empty");
+    let found = results
+        .iter()
+        .any(|r| r["path"].as_str().is_some_and(|p| p == "src/empty.ts"));
+    assert!(!found, "empty.ts should not appear in search results");
+}
+
+#[test]
+fn e2e_code_status_shows_file_types() {
+    let dir = setup_code_dir();
+    common::run_index(dir.path());
+
+    let status = common::run_status_json(dir.path());
+
+    // Verify file_type_counts
+    let counts = &status["file_type_counts"];
+    assert_eq!(counts["markdown"], 1, "should have 1 markdown file");
+    assert_eq!(
+        counts["typescript"], 1,
+        "should have 1 typescript file (empty.ts produces 0 sections, not in manifest)"
+    );
+    assert_eq!(counts["python"], 1, "should have 1 python file");
+
+    // Verify symbol_count > 0
+    let symbol_count = status["symbol_count"].as_u64().unwrap();
+    assert!(
+        symbol_count > 0,
+        "symbol_count should be > 0, got: {symbol_count}"
+    );
+}
+
+#[test]
+fn e2e_code_search_type_filter() {
+    let dir = setup_code_dir();
+    common::run_index(dir.path());
+
+    // --type typescript should only return .ts files
+    let output = common::cmd()
+        .args([
+            "search",
+            "greet",
+            "--type",
+            "typescript",
+            "--format",
+            "json",
+        ])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&output.get_output().stdout);
+    let results = common::parse_jsonl(&stdout);
+
+    for r in &results {
+        let path = r["path"].as_str().unwrap();
+        assert!(
+            path.ends_with(".ts") || path.ends_with(".tsx"),
+            "all results should be TypeScript files, got: {path}"
+        );
+    }
+
+    // --type code should return .ts and .py files
+    let output = common::cmd()
+        .args(["search", "function", "--type", "code", "--format", "json"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&output.get_output().stdout);
+    let results = common::parse_jsonl(&stdout);
+
+    for r in &results {
+        let path = r["path"].as_str().unwrap();
+        assert!(
+            !path.ends_with(".md"),
+            "--type code results should not contain .md files, got: {path}"
+        );
+    }
+}

--- a/tests/indexer_state.rs
+++ b/tests/indexer_state.rs
@@ -1,5 +1,5 @@
 use chrono::Utc;
-use commandindex::indexer::manifest::{self, FileEntry, Manifest};
+use commandindex::indexer::manifest::{self, FileEntry, FileType, Manifest};
 use commandindex::indexer::state::IndexState;
 use std::fs;
 use std::path::PathBuf;
@@ -98,6 +98,7 @@ fn test_manifest_add_entry() {
         hash: "sha256:abc123".to_string(),
         last_modified: Utc::now(),
         sections: 5,
+        file_type: FileType::Markdown,
     });
     assert_eq!(manifest.file_count(), 1);
 }
@@ -110,12 +111,14 @@ fn test_manifest_find_by_path() {
         hash: "sha256:abc123".to_string(),
         last_modified: Utc::now(),
         sections: 5,
+        file_type: FileType::Markdown,
     });
     manifest.add_entry(FileEntry {
         path: "docs/api.md".to_string(),
         hash: "sha256:def456".to_string(),
         last_modified: Utc::now(),
         sections: 3,
+        file_type: FileType::Markdown,
     });
 
     let entry = manifest.find_by_path("docs/auth.md");
@@ -136,6 +139,7 @@ fn test_manifest_save_and_load() {
         hash: "sha256:abc123".to_string(),
         last_modified: Utc::now(),
         sections: 5,
+        file_type: FileType::Markdown,
     });
 
     manifest.save(&ci_dir).unwrap();
@@ -208,6 +212,7 @@ fn manifest_remove_by_path_removes_entry() {
         hash: "sha256:aaa".to_string(),
         last_modified: Utc::now(),
         sections: 2,
+        file_type: FileType::Markdown,
     });
     assert_eq!(manifest.file_count(), 1);
 
@@ -224,6 +229,7 @@ fn manifest_remove_by_path_nonexistent_is_noop() {
         hash: "sha256:bbb".to_string(),
         last_modified: Utc::now(),
         sections: 1,
+        file_type: FileType::Markdown,
     });
     let count_before = manifest.file_count();
 
@@ -241,6 +247,7 @@ fn manifest_upsert_entry_adds_new() {
         hash: "sha256:ccc".to_string(),
         last_modified: Utc::now(),
         sections: 3,
+        file_type: FileType::Markdown,
     });
     assert_eq!(manifest.file_count(), 1);
     assert!(manifest.find_by_path("docs/new.md").is_some());
@@ -254,6 +261,7 @@ fn manifest_upsert_entry_updates_existing() {
         hash: "sha256:old".to_string(),
         last_modified: Utc::now(),
         sections: 1,
+        file_type: FileType::Markdown,
     });
 
     manifest.upsert_entry(FileEntry {
@@ -261,6 +269,7 @@ fn manifest_upsert_entry_updates_existing() {
         hash: "sha256:new".to_string(),
         last_modified: Utc::now(),
         sections: 5,
+        file_type: FileType::Markdown,
     });
 
     assert_eq!(manifest.file_count(), 1);


### PR DESCRIPTION
## Summary
- index/updateでTypeScript/Pythonファイルを解析しtantivy+symbols.dbに格納
- FileEntryにfile_type追加、statusにコードファイル数表示
- 差分更新時のsymbols.db連携
- E2Eテスト追加（910行の変更）

Closes #37
🤖 Generated with [Claude Code](https://claude.com/claude-code)